### PR TITLE
Use Oj instead of ActiveSupport::JSON

### DIFF
--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'arelastic', '>= 0.7.0'
   s.add_dependency 'activemodel'
+  s.add_dependency 'oj'
 end

--- a/lib/elastic_record/connection.rb
+++ b/lib/elastic_record/connection.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'oj'
 
 module ElasticRecord
   class Connection
@@ -37,10 +38,10 @@ module ElasticRecord
     end
 
     def json_request(method, path, json)
-      body = json.is_a?(Hash) ? ActiveSupport::JSON.encode(json) : json
+      body = json.is_a?(Hash) ? Oj.dump(json, :mode => :compat) : json
       response = http_request_with_retry(method, path, body)
 
-      json = ActiveSupport::JSON.decode response.body
+      json = Oj.compat_load(response.body)
       raise ConnectionError.new(response.code, json['error']) if json['error']
 
       json

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -64,7 +64,7 @@ module ElasticRecord
         yield
 
         if current_bulk_batch.any?
-          body = current_bulk_batch.map { |action| "#{ActiveSupport::JSON.encode(action)}\n" }.join
+          body = current_bulk_batch.map { |action| "#{Oj.dump(action, :mode => :compat)}\n" }.join
           results = connection.json_post("/_bulk?#{options.to_query}", body)
           verify_bulk_results(results)
         end

--- a/test/elastic_record/connection_test.rb
+++ b/test/elastic_record/connection_test.rb
@@ -21,7 +21,7 @@ class ElasticRecord::ConnectionTest < MiniTest::Test
 
   def test_json_requests
     expected = {'foo' => 'bar'}
-    FakeWeb.register_uri(:any, %r[/test], status: ["200", "OK"], body: ActiveSupport::JSON.encode(expected))
+    FakeWeb.register_uri(:any, %r[/test], status: ["200", "OK"], body: Oj.dump(expected))
 
     assert_equal expected, connection.json_delete("/test")
     assert_equal expected, connection.json_get("/test")
@@ -31,7 +31,7 @@ class ElasticRecord::ConnectionTest < MiniTest::Test
 
   def test_json_request_with_valid_error_status
     response_json = {'error' => 'Doing it wrong'}
-    FakeWeb.register_uri(:get, %r[/error], status: ["404", "Not Found"], body: ActiveSupport::JSON.encode(response_json))
+    FakeWeb.register_uri(:get, %r[/error], status: ["404", "Not Found"], body: Oj.dump(response_json))
 
     error = assert_raises ElasticRecord::ConnectionError do
       connection.json_get("/error")
@@ -43,7 +43,7 @@ class ElasticRecord::ConnectionTest < MiniTest::Test
   def test_retry_server_exceptions
     responses = [
       {exception: Errno::ECONNREFUSED},
-      {status: ["200", "OK"], body: ActiveSupport::JSON.encode('hello' => 'world')}
+      {status: ["200", "OK"], body: Oj.dump('hello' => 'world')}
     ]
 
     ElasticRecord::Connection.new(ElasticRecord::Config.servers, retries: 0).tap do |connection|

--- a/test/elastic_record/log_subscriber_test.rb
+++ b/test/elastic_record/log_subscriber_test.rb
@@ -16,25 +16,25 @@ class ElasticRecord::LogSubscriberTest < ActiveSupport::TestCase
   # end
 
   def test_request_notification
-    FakeWeb.register_uri(:any, %r[/test], status: ["200", "OK"], body: ActiveSupport::JSON.encode('the' => 'response'))
+    FakeWeb.register_uri(:any, %r[/test], status: ["200", "OK"], body: Oj.dump('the' => 'response'))
     Widget.elastic_connection.json_get "/widgets", {'foo' => 'bar'}
 
     wait
 
     assert_equal 1, @logger.logged(:debug).size
     assert_match /GET (.*)widgets/, @logger.logged(:debug)[0]
-    assert_match %r['#{ActiveSupport::JSON.encode('foo' => 'bar')}'], @logger.logged(:debug)[0]
+    assert_match %r['#{Oj.dump('foo' => 'bar')}'], @logger.logged(:debug)[0]
   end
 
   def test_request_notification_escaping
-    FakeWeb.register_uri(:any, %r[/widgets?v=%DB], status: ["200", "OK"], body: ActiveSupport::JSON.encode('the' => 'response', 'has %DB' => 'odd %DB stuff'))
+    FakeWeb.register_uri(:any, %r[/widgets?v=%DB], status: ["200", "OK"], body: Oj.dump('the' => 'response', 'has %DB' => 'odd %DB stuff'))
     Widget.elastic_connection.json_get "/widgets?v=%DB", {'foo' => 'bar', 'escape %DB ' => 'request %DB'}
 
     wait
 
     assert_equal 1, @logger.logged(:debug).size
     assert_match /GET (.*)widgets/, @logger.logged(:debug)[0]
-    assert_match %r['#{ActiveSupport::JSON.encode('foo' => 'bar', 'escape %DB ' => 'request %DB')}'], @logger.logged(:debug)[0]
+    assert_match %r['#{Oj.dump('foo' => 'bar', 'escape %DB ' => 'request %DB')}'], @logger.logged(:debug)[0]
   end
 
   def test_initializes_runtime


### PR DESCRIPTION
Testing a script that creates 250,000 records (in bulk batches of 500) showed a significant speed increase (~62%).