### PR TITLE
Use Oj optionally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,7 @@ gem 'rails', '~> 4.2.0'
 gem 'fakeweb'
 gem 'rake'
 
+gem 'oj'
+
 gem 'mysql2'
 gem 'pg'

--- a/README.rdoc
+++ b/README.rdoc
@@ -136,6 +136,13 @@ Create the index:
 
   rake index:create
 
+There is a gem-wide configuration setting to use the Oj gem for JSON (de)serialization, instead of
+ActiveSupport::JSON. In the appropriate location, require the Oj gem and set:
+
+  ElasticRecord.json_parser = :oj
+
+To return to the default parser, set the variable to :active_support.
+
 == Index Administration
 
 Core and Index APIs can be accessed with Product.elastic_index. Some examples include:

--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'arelastic', '>= 0.7.0'
   s.add_dependency 'activemodel'
-  s.add_dependency 'oj'
 end

--- a/lib/elastic_record.rb
+++ b/lib/elastic_record.rb
@@ -17,6 +17,14 @@ module ElasticRecord
     def configure
       yield(ElasticRecord::Config)
     end
+
+    def json_parser
+      @@json_parser ||= :active_support
+    end
+
+    def json_parser=(value)
+      @@json_parser = value
+    end
   end
 end
 

--- a/lib/elastic_record/connection.rb
+++ b/lib/elastic_record/connection.rb
@@ -48,7 +48,7 @@ module ElasticRecord
 
     def json_encode(data)
       if ElasticRecord.json_parser == :oj
-        Oj.dump(data, :mode => :compat)
+        Oj.dump(data, mode: :compat)
       else
         ActiveSupport::JSON.encode(data)
       end

--- a/lib/elastic_record/index/deferred.rb
+++ b/lib/elastic_record/index/deferred.rb
@@ -42,8 +42,10 @@ module ElasticRecord
 
         private
           READ_METHODS = [:json_get, :head]
+          SERIALIZE_METHODS = [:json_encode, :json_decode]
           def method_missing(method, *args, &block)
             super unless index.real_connection.respond_to?(method)
+            return index.real_connection.send(method, *args, &block) if SERIALIZE_METHODS.include?(method)
 
             if READ_METHODS.include?(method)
               flush!

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -64,7 +64,7 @@ module ElasticRecord
         yield
 
         if current_bulk_batch.any?
-          body = current_bulk_batch.map { |action| "#{Oj.dump(action, :mode => :compat)}\n" }.join
+          body = current_bulk_batch.map { |action| "#{connection.json_encode(action)}\n" }.join
           results = connection.json_post("/_bulk?#{options.to_query}", body)
           verify_bulk_results(results)
         end

--- a/lib/elastic_record/tasks/index.rake
+++ b/lib/elastic_record/tasks/index.rake
@@ -33,7 +33,7 @@ namespace :index do
       puts "Dropped #{model.name} index"
 
       if index.has_percolator
-        index_name = index.delete_percolator_index
+        index.delete_percolator_index
         puts "Dropped #{model.name} percolator index (#{index.percolator_name})"
       end
     end


### PR DESCRIPTION
This reverts the default JSON parser to `ActiveSupport::JSON`, and only uses Oj if:

1. `ElasticRecord.json_parser` is set to `:oj`
2. Oj is loaded

This should ease upgrading.