### PR TITLE
Deprecates ElasticRecord::Relation#each  This has been a continual so…

### DIFF
--- a/lib/elastic_record/relation/batches.rb
+++ b/lib/elastic_record/relation/batches.rb
@@ -25,10 +25,10 @@ module ElasticRecord
     end
 
     module Batches
-      # Delegates to Array, but should not be used as it only enumerates the first 10 records.
+      EACH_WITHOUT_LIMIT_WARNING = "#{self.name}#each should not be used without a limit.  Did you mean #find_each ?"
       def each(&block)
-        warn "warning: #{self.class.name}#each is deprecated and should not be used.  Did you mean #find_each?"
-        super
+        ActiveSupport::Deprecation.warn EACH_WITHOUT_LIMIT_WARNING if self.limit_value.nil?
+        super # Array
       end
 
       def find_each(options = {})

--- a/lib/elastic_record/relation/batches.rb
+++ b/lib/elastic_record/relation/batches.rb
@@ -25,6 +25,12 @@ module ElasticRecord
     end
 
     module Batches
+      # Delegates to Array, but should not be used as it only enumerates the first 10 records.
+      def each(&block)
+        warn "warning: #{self.class.name}#each is deprecated and should not be used.  Did you mean #find_each?"
+        super
+      end
+
       def find_each(options = {})
         find_in_batches(options) do |records|
           records.each { |record| yield record }

--- a/test/elastic_record/relation/batches_test.rb
+++ b/test/elastic_record/relation/batches_test.rb
@@ -71,6 +71,15 @@ class ElasticRecord::Relation::BatchesTest < MiniTest::Test
     assert_equal 3, scan_search.request_more_ids.size
   end
 
+  def test_each_should_not_be_used
+    results = []
+    Widget.elastic_relation.each do |widget|
+      results << widget.id
+    end
+
+    assert_equal ['5', '10', '15'].to_set, results.to_set
+  end
+
   private
     def create_widgets
       Widget.elastic_index.bulk_add [

--- a/test/elastic_record/relation/batches_test.rb
+++ b/test/elastic_record/relation/batches_test.rb
@@ -71,9 +71,22 @@ class ElasticRecord::Relation::BatchesTest < MiniTest::Test
     assert_equal 3, scan_search.request_more_ids.size
   end
 
-  def test_each_should_not_be_used
+  def test_each_should_not_be_used_without_limit
+    mock = Minitest::Mock.new
+    mock.expect(:call, nil, [String])
+    ActiveSupport::Deprecation.stub(:warn, mock) do
+      results = []
+      Widget.elastic_relation.each do |widget|
+        results << widget.id
+      end
+
+      assert_equal ['5', '10', '15'].to_set, results.to_set
+    end
+
+    mock.verify
+
     results = []
-    Widget.elastic_relation.each do |widget|
+    Widget.elastic_relation.limit(3).each do |widget|
       results << widget.id
     end
 


### PR DESCRIPTION
…urce of bugs for our team and is not a method you'd ever need to use anyway.

I am also open to aliasing each as for_each.