### PR TITLE
Add support for filter.not(color: 'red') and filter.nested('comments', 'comments.author' => 'Bob')

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
+gem 'arelastic', path: '~/code/arelastic'
 gem 'rails', '~> 4.2.0'
 gem 'fakeweb'
 gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'arelastic', path: '~/code/arelastic'
+
 gem 'rails', '~> 4.2.0'
 gem 'fakeweb'
 gem 'rake'

--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test}/*`.split("\n")
 
-  s.add_dependency 'arelastic', '>= 0.7.0'
+  s.add_dependency 'arelastic', '>= 0.9.0'
   s.add_dependency 'activemodel'
 end

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -213,9 +213,7 @@ module ElasticRecord
         end
 
         def build_filter_nodes(filters)
-          nodes = []
-
-          filters.each do |filter|
+          filters.each_with_object([]) do |filter, nodes|
             if filter.is_a?(Arelastic::Filters::Filter)
               nodes << filter
             elsif filter.is_a?(ElasticRecord::Relation)
@@ -235,8 +233,6 @@ module ElasticRecord
               end
             end
           end
-
-          nodes
         end
 
         def build_limit(limit)

--- a/test/elastic_record/relation/search_methods_test.rb
+++ b/test/elastic_record/relation/search_methods_test.rb
@@ -57,6 +57,43 @@ class ElasticRecord::Relation::SearchMethodsTest < MiniTest::Test
     assert_equal expected, relation.as_elastic['query']
   end
 
+  def test_filter_with_negation
+    scope = relation.filter.not("prefix" => {"name" => "Jo"})
+
+    expected = {
+      "filtered" => {
+        "filter" => {
+          "not" => {
+            "prefix" => {
+              "name" => "Jo"
+            }
+          }
+        }
+      }
+    }
+
+    assert_equal expected, scope.as_elastic['query']
+  end
+
+  def test_filter_with_nested
+    scope = relation.filter.nested("contacts", "prefix" => {"contacts.name" => "Jo"})
+
+    expected = {
+      "filtered" => {
+        "filter" => {
+          "nested" => {
+            "path" => "contacts",
+            "prefix" => {
+              "contacts.name" => "Jo"
+            }
+          }
+        }
+      }
+    }
+
+    assert_equal expected, scope.as_elastic['query']
+  end
+
   def test_query_with_only_query
     relation.query!('foo')
 


### PR DESCRIPTION
Provides some ActiveRecord parity:

Find all widgets where color is not red:

`Widget.filter.not(color: 'red')`

Find all nested objects, avoiding the need to build a painful nested filter:

`Business.filter.nested('executives', 'executives.first_name' => 'Bob')`

@data-axle/developers 