### PR TITLE
Replace fakeweb with webmock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'mysql2'
 gem 'pg'
 gem 'rails', '~> 4.2.0'
 gem 'rake', '~> 10.5.0'
-gem 'webmock'
+gem 'webmock', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'dotenv-rails'
-gem 'fakeweb'
 gem 'oj'
 gem 'mysql2'
 gem 'pg'
 gem 'rails', '~> 4.2.0'
 gem 'rake', '~> 10.5.0'
+gem 'webmock'

--- a/test/elastic_record/log_subscriber_test.rb
+++ b/test/elastic_record/log_subscriber_test.rb
@@ -16,7 +16,7 @@ class ElasticRecord::LogSubscriberTest < ActiveSupport::TestCase
   # end
 
   def test_request_notification
-    FakeWeb.register_uri(:any, %r[/test], status: ["200", "OK"], body: Oj.dump('the' => 'response'))
+    stub_request(:any, "#{Widget.elastic_connection.servers.first}/test").to_return(status: 200, body: Oj.dump('the' => 'response'))
     Widget.elastic_connection.json_get "/widgets", {'foo' => 'bar'}
 
     wait
@@ -27,7 +27,7 @@ class ElasticRecord::LogSubscriberTest < ActiveSupport::TestCase
   end
 
   def test_request_notification_escaping
-    FakeWeb.register_uri(:any, %r[/widgets?v=%DB], status: ["200", "OK"], body: Oj.dump('the' => 'response', 'has %DB' => 'odd %DB stuff'))
+    stub_request(:any, "#{Widget.elastic_connection.servers.first}/widgets?v=%DB").to_return(status: 200, body: Oj.dump('the' => 'response', 'has %DB' => 'odd %DB stuff'))
     Widget.elastic_connection.json_get "/widgets?v=%DB", {'foo' => 'bar', 'escape %DB ' => 'request %DB'}
 
     wait

--- a/test/elastic_record/log_subscriber_test.rb
+++ b/test/elastic_record/log_subscriber_test.rb
@@ -16,7 +16,7 @@ class ElasticRecord::LogSubscriberTest < ActiveSupport::TestCase
   # end
 
   def test_request_notification
-    stub_request(:any, "#{Widget.elastic_connection.servers.first}/test").to_return(status: 200, body: Oj.dump('the' => 'response'))
+    stub_request(:any, '/test').to_return(status: 200, body: Oj.dump('the' => 'response'))
     Widget.elastic_connection.json_get "/widgets", {'foo' => 'bar'}
 
     wait

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,15 +1,16 @@
 ENV["RAILS_ENV"] = "test"
 
-require File.expand_path("../../test/dummy/config/environment.rb",  __FILE__)
+require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
 
 require 'minitest/autorun'
 require 'webmock/minitest'
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 module MiniTest
   class Test
     def setup
       WebMock.reset!
-      WebMock.disable_net_connect!(allow_localhost: true)
 
       ElasticRecord::Config.models.each do |model|
         model.elastic_index.enable_deferring!

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,13 +3,13 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../../test/dummy/config/environment.rb",  __FILE__)
 
 require 'minitest/autorun'
-
-FakeWeb.allow_net_connect = %r[^https?://127.0.0.1]
+require 'webmock/minitest'
 
 module MiniTest
   class Test
     def setup
-      FakeWeb.clean_registry
+      WebMock.reset!
+      WebMock.disable_net_connect!(allow_localhost: true)
 
       ElasticRecord::Config.models.each do |model|
         model.elastic_index.enable_deferring!


### PR DESCRIPTION
fakeweb hasn't been updated since 2010. Meanwhile, webmock has been fairly actively maintained (the last release was last month). The switchover was fairly trivial.