### PR TITLE
Use as_search if it's available, even if our index mapping is not an

### DIFF
--- a/lib/elastic_record/callbacks.rb
+++ b/lib/elastic_record/callbacks.rb
@@ -60,7 +60,11 @@ module ElasticRecord
         when :nested
           value.map(&:as_search)
         else
-          value
+          if value.respond_to?(:as_search)
+            value.as_search
+          else
+            value
+          end
         end
 
       if value.present? || value == false


### PR DESCRIPTION
object.