### PR TITLE
Add configuration to load documents from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,28 @@ class Product
 end
 ```
 
+### Index documents From Source
+
+To fetch documents without an additional request to a backing ActiveRecord database you can load the documents from `_source`.
+
+```ruby
+Product.load_from_source do
+  Product.elastic_search.filter(name: "Pizza")
+end
+
+```
+
+Use `elastic_index.load_from_source = true` to build a model without ActiveRecord.
+
+```ruby
+class Product
+  include ActiveModel::Model
+  include ElasticRecord::Record
+
+  self.elastic_index.load_from_source = true
+end
+```
+
 ### Index Management ###
 
 If you need to manage multiple indexes via the rake tasks, you will need to declare them explicitly:

--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ end
 
 ### Load Documents from Source
 
+To fetch documents without an additional request to a backing ActiveRecord database you can load the documents from `_source`.
+
+```ruby
+Product.elastic_index.loading_from_source do
+  Product.elastic_search.filter(name: "Pizza")
+end
+
+```
+
 Use `elastic_index.load_from_source = true` to configure an index without ActiveRecord.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -196,16 +196,7 @@ end
 
 ### Load Documents from Source
 
-To fetch documents without an additional request to a backing ActiveRecord database you can load the documents from `_source`.
-
-```ruby
-Product.elastic_index.load_from_source do
-  Product.elastic_search.filter(name: "Pizza")
-end
-
-```
-
-Use `elastic_index.load_from_source = true` to build a model without ActiveRecord.
+Use `elastic_index.load_from_source = true` to configure an index without ActiveRecord.
 
 ```ruby
 class Product

--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'elastic_record'
-  s.version = '4.1.1'
+  s.version = '4.1.2'
   s.summary = 'An Elasticsearch querying ORM'
   s.description = 'Find your records with Elasticsearch'
 

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -66,16 +66,6 @@ module ElasticRecord
       @disabled = false
     end
 
-    def load_from_source(&block)
-      if block_given?
-        @load_from_source = true
-        yield
-        @load_from_source = false
-      else
-        @load_from_source
-      end
-    end
-
     def real_connection
       model.elastic_connection
     end

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -66,6 +66,13 @@ module ElasticRecord
       @disabled = false
     end
 
+    def loading_from_source(&block)
+      @load_from_source = true
+      yield
+    ensure
+      @load_from_source = false
+    end
+
     def real_connection
       model.elastic_connection
     end

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -37,6 +37,7 @@ module ElasticRecord
     attr_accessor :disabled
     attr_accessor :model
     attr_accessor :partial_updates
+    attr_accessor :load_from_source
 
     def initialize(models)
       models = Array.wrap(models)
@@ -63,6 +64,16 @@ module ElasticRecord
 
     def enable!
       @disabled = false
+    end
+
+    def load_from_source(&block)
+      if block_given?
+        @load_from_source = true
+        yield
+        @load_from_source = false
+      else
+        @load_from_source
+      end
     end
 
     def real_connection

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -62,11 +62,12 @@ module ElasticRecord
       klass.current_elastic_search = previous
     end
 
-    def search_hits
-      search_results['hits']['hits']
-    end
-
     private
+
+      def search_hits
+        search_results['hits']['hits']
+      end
+
       def reset
         @search_results = @records = nil
       end
@@ -85,7 +86,7 @@ module ElasticRecord
 
       def load_hits
         if klass.elastic_index.load_from_source
-           search_hits.map { |hit| klass.new(hit['_source'].merge('id' => hit['_id'])) }
+           search_hits.map { |hit| klass.new(hit['_source'].update('id' => hit['_id'])) }
         else
           scope = select_values.any? ? klass.select(select_values) : klass
           scope.find(to_ids)

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -85,7 +85,7 @@ module ElasticRecord
 
       def load_hits
         if klass.elastic_index.load_from_source
-           search_hits&.map { |hit| klass.new(hit['_source'].merge('id' => hit['_id'])) }
+           search_hits.map { |hit| klass.new(hit['_source'].merge('id' => hit['_id'])) }
         else
           scope = select_values.any? ? klass.select(select_values) : klass
           scope.find(to_ids)

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -35,7 +35,7 @@ module ElasticRecord
     end
 
     def to_a
-      @records ||= load_hits(to_ids)
+      @records ||= load_hits
     end
 
     def to_ids
@@ -79,9 +79,9 @@ module ElasticRecord
         end
       end
 
-      def load_hits(ids)
+      def load_hits
         scope = select_values.any? ? klass.select(select_values) : klass
-        scope.find(ids)
+        scope.find(to_ids)
       end
   end
 end

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -76,11 +76,11 @@ module ElasticRecord
         @search_results ||= begin
           options = search_type_value ? {search_type: search_type_value} : {}
 
-          if klass.elastic_index.load_from_source
-            klass.elastic_index.search(as_elastic, options)
-          else
-            klass.elastic_index.search(as_elastic.update('_source' => false), options)
+          unless klass.elastic_index.load_from_source
+            as_elastic.update('_source' => false)
           end
+
+          klass.elastic_index.search(as_elastic, options)
         end
       end
 

--- a/lib/elastic_record/tasks/index.rake
+++ b/lib/elastic_record/tasks/index.rake
@@ -51,9 +51,13 @@ namespace :index do
         index_name = model.elastic_index.create
       end
 
-      puts "  Reindexing into #{index_name}"
-      model.find_in_batches(batch_size: 100) do |records|
-        model.elastic_index.bulk_add(records, index_name: index_name)
+      if model.elastic_index.load_from_source
+        puts "  Reindexing into #{index_name} [skipped]"
+      else
+        puts "  Reindexing into #{index_name}"
+        model.find_in_batches(batch_size: 100) do |records|
+          model.elastic_index.bulk_add(records, index_name: index_name)
+        end
       end
 
       puts "  Deploying index..."

--- a/test/dummy/.env.test
+++ b/test/dummy/.env.test
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://localhost/elastic_record_test
+DATABASE_URL=postgres://localhost/elastic_record_subtest

--- a/test/elastic_record/index_test.rb
+++ b/test/elastic_record/index_test.rb
@@ -28,6 +28,13 @@ class ElasticRecord::IndexTest < MiniTest::Test
     refute index.disabled
   end
 
+  def test_loading_from_source
+    index.loading_from_source do
+      assert index.load_from_source
+    end
+    refute index.load_from_source
+  end
+
   private
 
     def index

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -43,17 +43,16 @@ class ElasticRecord::RelationTest < MiniTest::Test
   end
 
   def test_to_a_from_source
-    Widget.elastic_index.load_from_source = true
+    Widget.elastic_index.loading_from_source do
+      create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
 
-    create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+      array = Widget.elastic_relation.to_a
 
-    array = Widget.elastic_relation.to_a
-
-    assert_equal 2, array.size
-    assert array.first.is_a?(Widget)
-
-  ensure
-    Widget.elastic_index.load_from_source = false
+      assert_equal 2, array.size
+      assert array.first.is_a?(Widget)
+      assert_equal 'red', array.first.color
+      assert_equal 'blue', array.last.color
+    end
   end
 
   def test_delete_all

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -52,6 +52,7 @@ class ElasticRecord::RelationTest < MiniTest::Test
     assert_equal 2, array.size
     assert array.first.is_a?(Widget)
 
+  ensure
     Widget.elastic_index.load_from_source = false
   end
 

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -43,14 +43,16 @@ class ElasticRecord::RelationTest < MiniTest::Test
   end
 
   def test_to_a_from_source
-    Widget.elastic_index.load_from_source do
-      create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+    Widget.elastic_index.load_from_source = true
 
-      array = Widget.elastic_relation.to_a
+    create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
 
-      assert_equal 2, array.size
-      assert array.first.is_a?(Widget)
-    end
+    array = Widget.elastic_relation.to_a
+
+    assert_equal 2, array.size
+    assert array.first.is_a?(Widget)
+
+    Widget.elastic_index.load_from_source = false
   end
 
   def test_delete_all

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -42,6 +42,17 @@ class ElasticRecord::RelationTest < MiniTest::Test
     assert array.first.is_a?(Widget)
   end
 
+  def test_to_a_from_source
+    Widget.elastic_index.load_from_source do
+      create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+
+      array = Widget.elastic_relation.to_a
+
+      assert_equal 2, array.size
+      assert array.first.is_a?(Widget)
+    end
+  end
+
   def test_delete_all
     project_red = Project.create! name: 'Red'
     project_blue = Project.create! name: 'Blue'


### PR DESCRIPTION
To fetch documents without an additional request to a backing ActiveRecord database you can load the documents from `_source`.

```ruby
Product.elastic_index.loading_from_source do
  Product.elastic_search.filter(name: "Pizza")
end

```

Use `elastic_index.load_from_source = true` to configure an index without ActiveRecord.

```ruby
class Product
  include ActiveModel::Model
  include ElasticRecord::Record

  self.elastic_index.load_from_source = true
end
```