### PR TITLE
Support Automatic ID Generation

### DIFF
--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -93,6 +93,7 @@ module ElasticRecord
       end
 
       def update_document(id, document, doctype: model.doctype, parent: nil, index_name: alias_name)
+        raise "Cannot update a document with empty id" if id.blank?
         params = {doc: document, doc_as_upsert: true}
 
         if batch = current_bulk_batch

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -54,7 +54,7 @@ module ElasticRecord
       def index_record(record, index_name: alias_name)
         unless disabled
           index_document(
-            record.send(record.class.primary_key),
+            record_primary_key(record),
             record.as_search_document,
             doctype: record.doctype,
             index_name: index_name
@@ -197,6 +197,11 @@ module ElasticRecord
           end
 
           raise ElasticRecord::BulkError.new(errors) unless errors.empty?
+        end
+
+        def record_primary_key(record)
+          primary_key_name = record.class.try(:primary_key)
+          record.try(primary_key_name) if primary_key_name
         end
     end
   end

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -93,7 +93,7 @@ module ElasticRecord
       end
 
       def update_document(id, document, doctype: model.doctype, parent: nil, index_name: alias_name)
-        raise "Cannot update a document with empty id" if id.blank?
+        raise ElasticRecord::Error, "Cannot update a document with empty id" if id.blank?
         params = {doc: document, doc_as_upsert: true}
 
         if batch = current_bulk_batch
@@ -111,7 +111,7 @@ module ElasticRecord
       end
 
       def delete_document(id, doctype: model.doctype, parent: nil, index_name: alias_name)
-        raise "Cannot delete document with empty id" if id.blank?
+        raise ElasticRecord::Error, "Cannot delete document with empty id" if id.blank?
         index_name ||= alias_name
 
         if batch = current_bulk_batch

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -84,7 +84,11 @@ module ElasticRecord
           path = "/#{index_name}/#{doctype.name}/#{id}"
           path << "?parent=#{parent}" if parent
 
-          connection.json_put path, document
+          if id
+            connection.json_put path, document
+          else
+            connection.json_post path, document
+          end
         end
       end
 

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -54,7 +54,7 @@ module ElasticRecord
       def index_record(record, index_name: alias_name)
         unless disabled
           index_document(
-            record_primary_key(record),
+            record.try(:id),
             record.as_search_document,
             doctype: record.doctype,
             index_name: index_name
@@ -65,7 +65,7 @@ module ElasticRecord
       def update_record(record, index_name: alias_name)
         unless disabled
           update_document(
-            record.send(record.class.primary_key),
+            record.try(:id),
             record.as_partial_update_document,
             doctype: record.doctype,
             index_name: index_name
@@ -197,11 +197,6 @@ module ElasticRecord
           end
 
           raise ElasticRecord::BulkError.new(errors) unless errors.empty?
-        end
-
-        def record_primary_key(record)
-          primary_key_name = record.class.try(:primary_key)
-          record.try(primary_key_name) if primary_key_name
         end
     end
   end

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -65,7 +65,7 @@ module ElasticRecord
       def update_record(record, index_name: alias_name)
         unless disabled
           update_document(
-            record.try(:id),
+            record.id,
             record.as_partial_update_document,
             doctype: record.doctype,
             index_name: index_name

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -93,7 +93,7 @@ module ElasticRecord
       end
 
       def update_document(id, document, doctype: model.doctype, parent: nil, index_name: alias_name)
-        raise ElasticRecord::Error, "Cannot update a document with empty id" if id.blank?
+        raise "Cannot update a document with empty id" if id.blank?
         params = {doc: document, doc_as_upsert: true}
 
         if batch = current_bulk_batch
@@ -111,7 +111,7 @@ module ElasticRecord
       end
 
       def delete_document(id, doctype: model.doctype, parent: nil, index_name: alias_name)
-        raise ElasticRecord::Error, "Cannot delete document with empty id" if id.blank?
+        raise "Cannot delete document with empty id" if id.blank?
         index_name ||= alias_name
 
         if batch = current_bulk_batch

--- a/test/dummy/app/models/warehouse.rb
+++ b/test/dummy/app/models/warehouse.rb
@@ -1,5 +1,15 @@
 class Warehouse
-  include TestModel
+  class << self
+    def base_class
+      self
+    end
+  end
 
-  define_attributes [:name]
+  include ActiveModel::Model
+  include ElasticRecord::Model
+
+  attr_accessor :id, :name
+  alias_method :as_json, :as_search_document
+
+  elastic_index.load_from_source = true
 end

--- a/test/dummy/app/models/warehouse.rb
+++ b/test/dummy/app/models/warehouse.rb
@@ -12,4 +12,8 @@ class Warehouse
   alias_method :as_json, :as_search_document
 
   elastic_index.load_from_source = true
+
+  def as_search_document
+    { name: name }
+  end
 end

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -50,6 +50,10 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
 
     expected = {'warehouse_id' => '5', 'color' => 'blue'}
     assert_equal expected, index.get('abc', Widget.doctype)['_source']
+
+    assert_raises RuntimeError do
+      index.update_document(nil, color: 'blue')
+    end
   end
 
   def test_delete_document

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -23,6 +23,15 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     refute index.record_exists?('xyz')
   end
 
+  def test_index_document_without_id
+    without_deferring do
+      result = index.index_document(nil, color: 'red')
+
+      assert index.record_exists?(result['_id'])
+      refute index.record_exists?('xyz')
+    end
+  end
+
   def test_update_document
     index.index_document('abc', warehouse_id: '5', color: 'red')
     index.update_document('abc', color: 'blue')

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -51,7 +51,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     expected = {'warehouse_id' => '5', 'color' => 'blue'}
     assert_equal expected, index.get('abc', Widget.doctype)['_source']
 
-    assert_raises ElasticRecord::Error do
+    assert_raises RuntimeError do
       index.update_document(nil, color: 'blue')
     end
   end
@@ -63,7 +63,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     index.delete_document('abc')
     refute index.record_exists?('abc')
 
-    assert_raises ElasticRecord::Error do
+    assert_raises RuntimeError do
       index.delete_document('')
     end
   end

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -51,7 +51,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     expected = {'warehouse_id' => '5', 'color' => 'blue'}
     assert_equal expected, index.get('abc', Widget.doctype)['_source']
 
-    assert_raises RuntimeError do
+    assert_raises ElasticRecord::Error do
       index.update_document(nil, color: 'blue')
     end
   end
@@ -63,7 +63,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     index.delete_document('abc')
     refute index.record_exists?('abc')
 
-    assert_raises RuntimeError do
+    assert_raises ElasticRecord::Error do
       index.delete_document('')
     end
   end

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -44,14 +44,15 @@ class ElasticRecord::RelationTest < MiniTest::Test
 
   def test_to_a_from_source
     warehouses = [Warehouse.new(name: 'Amazon'), Warehouse.new(name: 'Walmart')]
-    Warehouse.elastic_index.bulk_add(warehouses)
+    result = Warehouse.elastic_index.bulk_add(warehouses)
 
     array = Warehouse.elastic_relation.to_a
 
     assert_equal 2, array.size
     assert array.first.is_a?(Warehouse)
-    assert_equal 'Amazon', array.first.name
-    assert_equal 'Walmart', array.last.name
+    names = array.map(&:name)
+    assert_includes names, 'Amazon'
+    assert_includes names, 'Walmart'
   end
 
   def test_delete_all

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -43,16 +43,15 @@ class ElasticRecord::RelationTest < MiniTest::Test
   end
 
   def test_to_a_from_source
-    Widget.elastic_index.loading_from_source do
-      create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+    warehouses = [Warehouse.new(name: 'Amazon'), Warehouse.new(name: 'Walmart')]
+    Warehouse.elastic_index.bulk_add(warehouses)
 
-      array = Widget.elastic_relation.to_a
+    array = Warehouse.elastic_relation.to_a
 
-      assert_equal 2, array.size
-      assert array.first.is_a?(Widget)
-      assert_equal 'red', array.first.color
-      assert_equal 'blue', array.last.color
-    end
+    assert_equal 2, array.size
+    assert array.first.is_a?(Warehouse)
+    assert_equal 'Amazon', array.first.name
+    assert_equal 'Walmart', array.last.name
   end
 
   def test_delete_all


### PR DESCRIPTION
ElasticSearch supports [automatically generating an ID for documents](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/docs-index_.html#_automatic_id_generation) where id is not specified. To automatically generate an id with ElasticSearch the document must be sent as a `POST` request to the index.

This adds a condition to `ElasticRecord::Index::Documents#index_document` which will `POST` a document to the index if no id is specified.