### PR TITLE
Finding in batches respects sort if it was provided

### DIFF
--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -44,7 +44,7 @@ module ElasticRecord
       def initial_search_response
         @initial_search_response ||= begin
           search_options = {size: batch_size, scroll: keep_alive}
-          elastic_query = @search.merge('sort' => '_doc')
+          elastic_query = @search.reverse_merge('sort' => '_doc')
           @elastic_index.search(elastic_query, search_options)
         end
       end

--- a/test/elastic_record/relation/batches_test.rb
+++ b/test/elastic_record/relation/batches_test.rb
@@ -22,6 +22,15 @@ class ElasticRecord::Relation::BatchesTest < MiniTest::Test
     assert_equal [['5', '10', '15'].to_set], results.map(&:to_set)
   end
 
+  def test_find_ids_in_batches_with_order
+    results = []
+    Widget.elastic_relation.order(color: :asc).find_ids_in_batches do |ids|
+      results << ids
+    end
+
+    assert_equal [['10', '15', '5']], results
+  end
+
   def test_find_ids_in_batches_with_size
     results = []
     Widget.elastic_relation.find_ids_in_batches(batch_size: 2) do |ids|


### PR DESCRIPTION
From the ES docs:

> _doc has no real use-case besides being the most efficient sort order. So if you don’t care about the order in which documents are returned, then you should sort by _doc. This especially helps when scrolling.

For DAX-3334, I care about the order and I don't want it overwritten with _doc.