### PR TITLE
Support source options with batch methods

### DIFF
--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -147,7 +147,7 @@ module ElasticRecord
           url += "?#{options.to_query}"
         end
 
-        get url, model.doctype, elastic_query
+        get url, model.doctype, elastic_query.update('_source' => load_from_source)
       end
 
       def explain(id, elastic_query)

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -39,10 +39,6 @@ module ElasticRecord
       @records ||= load_hits(search_hits)
     end
 
-    def to_ids
-      map_hits_to_ids search_hits
-    end
-
     def delete_all
       find_ids_in_batches { |ids| klass.delete(ids) }
       klass.elastic_index.delete_by_query(as_elastic)
@@ -65,20 +61,9 @@ module ElasticRecord
 
     private
 
-      def search_hits
-        search_results['hits']['hits']
-      end
-
       def reset
         @search_results = @records = nil
       end
 
-      def search_results
-        @search_results ||= begin
-          options = search_type_value ? {search_type: search_type_value} : {}
-
-          klass.elastic_index.search(as_elastic, options)
-        end
-      end
   end
 end

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -76,9 +76,8 @@ module ElasticRecord
       def search_results
         @search_results ||= begin
           options = search_type_value ? {search_type: search_type_value} : {}
-          search = as_elastic.update('_source' => klass.elastic_index.load_from_source)
 
-          klass.elastic_index.search(search, options)
+          klass.elastic_index.search(as_elastic, options)
         end
       end
   end

--- a/lib/elastic_record/relation/batches.rb
+++ b/lib/elastic_record/relation/batches.rb
@@ -15,7 +15,7 @@ module ElasticRecord
 
       def find_ids_in_batches(options = {}, &block)
         build_scroll_enumerator(options).each_slice do |hits|
-          map_hits_to_ids hits
+          yield map_hits_to_ids(hits)
         end
       end
 

--- a/lib/elastic_record/relation/batches.rb
+++ b/lib/elastic_record/relation/batches.rb
@@ -8,13 +8,15 @@ module ElasticRecord
       end
 
       def find_in_batches(options = {})
-        find_ids_in_batches(options) do |ids|
-          yield klass.where(id: ids)
+        build_scroll_enumerator(options).each_slice do |hits|
+          yield load_hits(hits)
         end
       end
 
       def find_ids_in_batches(options = {}, &block)
-        build_scroll_enumerator(options).each_slice(&block)
+        build_scroll_enumerator(options).each_slice do |hits|
+          map_hits_to_ids hits
+        end
       end
 
       def build_scroll_enumerator(options)

--- a/lib/elastic_record/relation/hits.rb
+++ b/lib/elastic_record/relation/hits.rb
@@ -1,0 +1,18 @@
+module ElasticRecord
+  class Relation
+    module Hits
+      def load_hits(search_hits)
+        if klass.elastic_index.load_from_source
+           search_hits.map { |hit| klass.new(hit['_source'].update('id' => hit['_id'])) }
+        else
+          scope = select_values.any? ? klass.select(select_values) : klass
+          scope.find map_hits_to_ids(search_hits)
+        end
+      end
+
+      def map_hits_to_ids(hits)
+        hits.map { |hit| hit['_id'] }
+      end
+    end
+  end
+end

--- a/lib/elastic_record/relation/hits.rb
+++ b/lib/elastic_record/relation/hits.rb
@@ -1,6 +1,10 @@
 module ElasticRecord
   class Relation
     module Hits
+      def to_ids
+        map_hits_to_ids search_hits
+      end
+
       def load_hits(search_hits)
         if klass.elastic_index.load_from_source
            search_hits.map { |hit| klass.new(hit['_source'].update('id' => hit['_id'])) }
@@ -13,6 +17,22 @@ module ElasticRecord
       def map_hits_to_ids(hits)
         hits.map { |hit| hit['_id'] }
       end
+
+      private
+
+        def search_hits
+          search_results['hits']['hits']
+        end
+
+
+        def search_results
+          @search_results ||= begin
+            options = search_type_value ? {search_type: search_type_value} : {}
+
+            klass.elastic_index.search(as_elastic, options)
+          end
+        end
+
     end
   end
 end

--- a/test/elastic_record/relation/hits_test.rb
+++ b/test/elastic_record/relation/hits_test.rb
@@ -1,0 +1,35 @@
+require 'helper'
+
+class ElasticRecord::Relation::HitsTest < MiniTest::Test
+  def test_to_hits
+    # assert Widget.elastic_relation.search_results.is_a?(ElasticSearch::Api::Hits)
+  end
+
+  def test_to_ids
+    Widget.elastic_index.bulk_add [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+
+    assert_equal ['5', '10'].to_set, Widget.elastic_relation.to_ids.to_set
+  end
+
+  def test_to_a
+    Widget.elastic_index.bulk_add [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+
+    array = Widget.elastic_relation.to_a
+
+    assert_equal 2, array.size
+    assert array.first.is_a?(Widget)
+  end
+
+  def test_to_a_from_source
+    warehouses = [Warehouse.new(name: 'Amazon'), Warehouse.new(name: 'Walmart')]
+    result = Warehouse.elastic_index.bulk_add(warehouses)
+
+    array = Warehouse.elastic_relation.to_a
+
+    assert_equal 2, array.size
+    assert array.first.is_a?(Warehouse)
+    names = array.map(&:name)
+    assert_includes names, 'Amazon'
+    assert_includes names, 'Walmart'
+  end
+end

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -23,38 +23,6 @@ class ElasticRecord::RelationTest < MiniTest::Test
     # explain = Widget.elastic_relation.filter(color: 'blue').explain('10')
   end
 
-  def test_to_hits
-    # assert Widget.elastic_relation.search_results.is_a?(ElasticSearch::Api::Hits)
-  end
-
-  def test_to_ids
-    create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
-
-    assert_equal ['5', '10'].to_set, Widget.elastic_relation.to_ids.to_set
-  end
-
-  def test_to_a
-    create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
-
-    array = Widget.elastic_relation.to_a
-
-    assert_equal 2, array.size
-    assert array.first.is_a?(Widget)
-  end
-
-  def test_to_a_from_source
-    warehouses = [Warehouse.new(name: 'Amazon'), Warehouse.new(name: 'Walmart')]
-    result = Warehouse.elastic_index.bulk_add(warehouses)
-
-    array = Warehouse.elastic_relation.to_a
-
-    assert_equal 2, array.size
-    assert array.first.is_a?(Warehouse)
-    names = array.map(&:name)
-    assert_includes names, 'Amazon'
-    assert_includes names, 'Walmart'
-  end
-
   def test_delete_all
     project_red = Project.create! name: 'Red'
     project_blue = Project.create! name: 'Blue'


### PR DESCRIPTION
`Relation::Batch` was misbehaving with `Index#load_from_source`. This PR fixes two issues:

Problem 1:

When `load_from_source=false`, source was still being loaded. This makes things _slow_!

Problem 2:

When `load_from_source=true`, the code tried to call `AR.where`, rather than respecting the option to use source.