### PR TITLE
Add BulkDocuments concern and make bulk operations threadsafe

### DIFF
--- a/lib/elastic_record/connection.rb
+++ b/lib/elastic_record/connection.rb
@@ -2,10 +2,13 @@ require 'net/http'
 
 module ElasticRecord
   class Connection
+    def self.bulk_stack
+      Thread.current['elastic_record_bulk_stack'] ||= []
+    end
+
     attr_accessor :servers, :options
     attr_accessor :request_count, :current_server
     attr_accessor :max_request_count
-    attr_accessor :bulk_stack
     def initialize(servers, options = {})
       self.servers = Array(servers)
 
@@ -14,7 +17,6 @@ module ElasticRecord
       self.request_count      = 0
       self.max_request_count  = 100
       self.options            = options.symbolize_keys
-      self.bulk_stack         = []
     end
 
     def head(path)

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -1,6 +1,7 @@
 require 'elastic_record/index/analyze'
 require 'elastic_record/index/deferred'
 require 'elastic_record/index/documents'
+require 'elastic_record/index/bulk_documents'
 require 'elastic_record/index/manage'
 require 'elastic_record/index/mapping'
 require 'elastic_record/index/settings'
@@ -27,6 +28,7 @@ module ElasticRecord
   #   Update elastic search's mapping
   class Index
     include Documents
+    include BulkDocuments
     include Manage
     include Mapping, Settings
     include Analyze

--- a/lib/elastic_record/index/bulk_documents.rb
+++ b/lib/elastic_record/index/bulk_documents.rb
@@ -16,8 +16,7 @@ module ElasticRecord
       end
 
       def update_document(id, document, doctype: model.doctype, parent: nil, index_name: alias_name)
-        raise "Cannot update a document with empty id" if id.blank?
-        params = {doc: document, doc_as_upsert: true}
+        params = validate_and_extract_update_params(id, document)
 
         if batch = current_bulk_batch
           instructions = { _index: index_name, _type: doctype.name, _id: id, _retry_on_conflict: 3 }

--- a/lib/elastic_record/index/bulk_documents.rb
+++ b/lib/elastic_record/index/bulk_documents.rb
@@ -44,7 +44,7 @@ module ElasticRecord
       end
 
       def bulk(options = {})
-        connection.bulk_stack.push []
+        ElasticRecord::Connection.bulk_stack.push []
 
         yield
 
@@ -54,7 +54,7 @@ module ElasticRecord
           verify_bulk_results(results)
         end
       ensure
-        connection.bulk_stack.pop
+        ElasticRecord::Connection.bulk_stack.pop
       end
 
       def bulk_add(batch, index_name: alias_name)
@@ -66,7 +66,7 @@ module ElasticRecord
       end
 
       def current_bulk_batch
-        connection.bulk_stack.last
+        ElasticRecord::Connection.bulk_stack.last
       end
 
       private

--- a/lib/elastic_record/index/bulk_documents.rb
+++ b/lib/elastic_record/index/bulk_documents.rb
@@ -31,8 +31,7 @@ module ElasticRecord
       end
 
       def delete_document(id, doctype: model.doctype, parent: nil, index_name: alias_name)
-        raise "Cannot delete document with empty id" if id.blank?
-        index_name ||= alias_name
+        validate_doc_deletion(id, index_name)
 
         if batch = current_bulk_batch
           instructions = { _index: index_name, _type: doctype.name, _id: id, _retry_on_conflict: 3 }

--- a/lib/elastic_record/index/bulk_documents.rb
+++ b/lib/elastic_record/index/bulk_documents.rb
@@ -1,0 +1,86 @@
+require 'active_support/core_ext/object/to_query'
+
+module ElasticRecord
+  class Index
+    module BulkDocuments
+      def index_document(id, document, doctype: model.doctype, parent: nil, index_name: alias_name)
+        p "ARE WE RUNNING bulk???"
+        if batch = current_bulk_batch
+          instructions = { _index: index_name, _type: doctype.name, _id: id }
+          instructions[:parent] = parent if parent
+
+          batch << { index: instructions }
+          batch << document
+        else
+          super
+        end
+      end
+
+      def update_document(id, document, doctype: model.doctype, parent: nil, index_name: alias_name)
+        raise "Cannot update a document with empty id" if id.blank?
+        params = {doc: document, doc_as_upsert: true}
+
+        if batch = current_bulk_batch
+          instructions = { _index: index_name, _type: doctype.name, _id: id, _retry_on_conflict: 3 }
+          instructions[:parent] = parent if parent
+
+          batch << { update: instructions }
+          batch << params
+        else
+          super
+        end
+      end
+
+      def delete_document(id, doctype: model.doctype, parent: nil, index_name: alias_name)
+        raise "Cannot delete document with empty id" if id.blank?
+        index_name ||= alias_name
+
+        if batch = current_bulk_batch
+          instructions = { _index: index_name, _type: doctype.name, _id: id, _retry_on_conflict: 3 }
+          instructions[:parent] = parent if parent
+          batch << { delete: instructions }
+        else
+          super
+        end
+      end
+
+      def bulk(options = {})
+        connection.bulk_stack.push []
+
+        yield
+
+        if current_bulk_batch.any?
+          body = current_bulk_batch.map { |action| "#{JSON.generate(action)}\n" }.join
+          results = connection.json_post("/_bulk?#{options.to_query}", body)
+          verify_bulk_results(results)
+        end
+      ensure
+        connection.bulk_stack.pop
+      end
+
+      def bulk_add(batch, index_name: alias_name)
+        bulk do
+          batch.each do |record|
+            index_record(record, index_name: index_name)
+          end
+        end
+      end
+
+      def current_bulk_batch
+        connection.bulk_stack.last
+      end
+
+      private
+
+        def verify_bulk_results(results)
+          return unless results.is_a?(Hash)
+
+          errors = results['items'].select do |item|
+            item.values.first['error']
+          end
+
+          raise ElasticRecord::BulkError.new(errors) unless errors.empty?
+        end
+    end
+  end
+end

--- a/lib/elastic_record/index/bulk_documents.rb
+++ b/lib/elastic_record/index/bulk_documents.rb
@@ -4,7 +4,6 @@ module ElasticRecord
   class Index
     module BulkDocuments
       def index_document(id, document, doctype: model.doctype, parent: nil, index_name: alias_name)
-        p "ARE WE RUNNING bulk???"
         if batch = current_bulk_batch
           instructions = { _index: index_name, _type: doctype.name, _id: id }
           instructions[:parent] = parent if parent

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -75,21 +75,13 @@ module ElasticRecord
       end
 
       def index_document(id, document, doctype: model.doctype, parent: nil, index_name: alias_name)
-        if batch = current_bulk_batch
-          instructions = { _index: index_name, _type: doctype.name, _id: id }
-          instructions[:parent] = parent if parent
+        path = "/#{index_name}/#{doctype.name}/#{id}"
+        path << "?parent=#{parent}" if parent
 
-          batch << { index: instructions }
-          batch << document
+        if id
+          connection.json_put path, document
         else
-          path = "/#{index_name}/#{doctype.name}/#{id}"
-          path << "?parent=#{parent}" if parent
-
-          if id
-            connection.json_put path, document
-          else
-            connection.json_post path, document
-          end
+          connection.json_post path, document
         end
       end
 
@@ -97,34 +89,19 @@ module ElasticRecord
         raise "Cannot update a document with empty id" if id.blank?
         params = {doc: document, doc_as_upsert: true}
 
-        if batch = current_bulk_batch
-          instructions = { _index: index_name, _type: doctype.name, _id: id, _retry_on_conflict: 3 }
-          instructions[:parent] = parent if parent
-
-          batch << { update: instructions }
-          batch << params
-        else
-          path = "/#{index_name}/#{doctype.name}/#{id}/_update?retry_on_conflict=3"
-          path << "&parent=#{parent}" if parent
-
-          connection.json_post path, params
-        end
+        path = "/#{index_name}/#{doctype.name}/#{id}/_update?retry_on_conflict=3"
+        path << "&parent=#{parent}" if parent
+        connection.json_post path, params
       end
 
       def delete_document(id, doctype: model.doctype, parent: nil, index_name: alias_name)
         raise "Cannot delete document with empty id" if id.blank?
         index_name ||= alias_name
 
-        if batch = current_bulk_batch
-          instructions = { _index: index_name, _type: doctype.name, _id: id, _retry_on_conflict: 3 }
-          instructions[:parent] = parent if parent
-          batch << { delete: instructions }
-        else
-          path = "/#{index_name}/#{doctype.name}/#{id}"
-          path << "&parent=#{parent}" if parent
+        path = "/#{index_name}/#{doctype.name}/#{id}"
+        path << "&parent=#{parent}" if parent
 
-          connection.json_delete path
-        end
+        connection.json_delete path
       end
 
       def delete_by_query(query)
@@ -163,43 +140,6 @@ module ElasticRecord
         connection.json_get("/_search/scroll?#{options.to_query}")
       end
 
-      def bulk(options = {})
-        connection.bulk_stack.push []
-
-        yield
-
-        if current_bulk_batch.any?
-          body = current_bulk_batch.map { |action| "#{JSON.generate(action)}\n" }.join
-          results = connection.json_post("/_bulk?#{options.to_query}", body)
-          verify_bulk_results(results)
-        end
-      ensure
-        connection.bulk_stack.pop
-      end
-
-      def bulk_add(batch, index_name: alias_name)
-        bulk do
-          batch.each do |record|
-            index_record(record, index_name: index_name)
-          end
-        end
-      end
-
-      def current_bulk_batch
-        connection.bulk_stack.last
-      end
-
-      private
-
-        def verify_bulk_results(results)
-          return unless results.is_a?(Hash)
-
-          errors = results['items'].select do |item|
-            item.values.first['error']
-          end
-
-          raise ElasticRecord::BulkError.new(errors) unless errors.empty?
-        end
     end
   end
 end

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -95,8 +95,7 @@ module ElasticRecord
       end
 
       def delete_document(id, doctype: model.doctype, parent: nil, index_name: alias_name)
-        raise "Cannot delete document with empty id" if id.blank?
-        index_name ||= alias_name
+        validate_doc_deletion(id, index_name)
 
         path = "/#{index_name}/#{doctype.name}/#{id}"
         path << "&parent=#{parent}" if parent
@@ -140,6 +139,12 @@ module ElasticRecord
         connection.json_get("/_search/scroll?#{options.to_query}")
       end
 
+      private
+
+      def validate_doc_deletion(id, index_name)
+        raise "Cannot delete document with empty id" if id.blank?
+        raise "Cannot delete document with empty index_name" if index_name.blank?
+      end
     end
   end
 end

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -86,8 +86,7 @@ module ElasticRecord
       end
 
       def update_document(id, document, doctype: model.doctype, parent: nil, index_name: alias_name)
-        raise "Cannot update a document with empty id" if id.blank?
-        params = {doc: document, doc_as_upsert: true}
+        params = validate_and_extract_update_params(id, document)
 
         path = "/#{index_name}/#{doctype.name}/#{id}/_update?retry_on_conflict=3"
         path << "&parent=#{parent}" if parent
@@ -144,6 +143,11 @@ module ElasticRecord
       def validate_doc_deletion(id, index_name)
         raise "Cannot delete document with empty id" if id.blank?
         raise "Cannot delete document with empty index_name" if index_name.blank?
+      end
+
+      def validate_and_extract_update_params(id, document)
+        raise "Cannot update a document with empty id" if id.blank?
+        {doc: document, doc_as_upsert: true}
       end
     end
   end

--- a/test/elastic_record/index/bulk_documents_test.rb
+++ b/test/elastic_record/index/bulk_documents_test.rb
@@ -1,0 +1,79 @@
+require 'helper'
+
+class ElasticRecord::Index::BulkDocumentsTest < MiniTest::Test
+  class InheritedWidget < Widget
+    def self.base_class
+      Widget
+    end
+  end
+
+  def test_bulk_add
+    record = Widget.new(id: 'abc', color: 'red')
+
+    index.bulk_add [record]
+
+    assert index.record_exists?('abc')
+    refute index.record_exists?('xyz')
+  end
+
+  def test_bulk
+    assert_nil index.instance_variable_get(:@_batch)
+
+    index.bulk do
+      index.index_document '5', color: 'green'
+      index.update_document '5', color: 'blue'
+      index.delete_document '3'
+
+      expected = [
+        {index: {_index: index.alias_name, _type: "widget", _id: "5"}},
+        {color: "green"},
+        {update: {_index: "widgets", _type: "widget", _id: "5", _retry_on_conflict: 3}},
+        {doc: {color: "blue"}, doc_as_upsert: true},
+        {delete: {_index: index.alias_name, _type: "widget", _id: "3", _retry_on_conflict: 3}}
+      ]
+      assert_equal expected, index.current_bulk_batch
+    end
+
+    assert_nil index.current_bulk_batch
+  end
+
+  def test_bulk_error
+    without_deferring(index) do
+      begin
+        index.bulk do
+          index.index_document '5', color: 'green'
+          index.index_document '3', color: {'bad' => 'stuff'}
+        end
+        refute index.record_exists?('3')
+        assert false, 'Expected ElasticRecord::BulkError'
+      rescue => e
+        assert_match '[{"index"', e.message
+      end
+    end
+  end
+
+  def test_bulk_inheritence
+    without_deferring(index) do
+      index.bulk do
+        InheritedWidget.elastic_index.index_document '5', color: 'green'
+
+        expected = [
+          {index: {_index: index.alias_name, _type: "widget", _id: "5"}},
+          {color: "green"}
+        ]
+        assert_equal expected, index.current_bulk_batch
+      end
+    end
+  end
+
+  def without_deferring(index)
+    index.disable_deferring!
+    yield
+    index.reset
+    index.enable_deferring!
+  end
+
+  def index
+    @index ||= Widget.elastic_index
+  end
+end

--- a/test/elastic_record/index/bulk_documents_test.rb
+++ b/test/elastic_record/index/bulk_documents_test.rb
@@ -66,12 +66,7 @@ class ElasticRecord::Index::BulkDocumentsTest < MiniTest::Test
     end
   end
 
-  def without_deferring(index)
-    index.disable_deferring!
-    yield
-    index.reset
-    index.enable_deferring!
-  end
+  private
 
   def index
     @index ||= Widget.elastic_index

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -84,13 +84,6 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
 
   private
 
-    def without_deferring(index)
-      index.disable_deferring!
-      yield
-      index.reset
-      index.enable_deferring!
-    end
-
     def index
       @index ||= Widget.elastic_index
     end

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -1,12 +1,6 @@
 require 'helper'
 
 class ElasticRecord::Index::DocumentsTest < MiniTest::Test
-  class InheritedWidget < Widget
-    def self.base_class
-      Widget
-    end
-  end
-
   def test_index_record
     record = Widget.new(id: '5', color: 'red')
 
@@ -86,65 +80,6 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
 
     assert_equal 1, scroll_enumerator.total_hits
     assert_equal 1, scroll_enumerator.request_more_ids.size
-  end
-
-  def test_bulk_add
-    record = Widget.new(id: 'abc', color: 'red')
-
-    index.bulk_add [record]
-
-    assert index.record_exists?('abc')
-    refute index.record_exists?('xyz')
-  end
-
-  def test_bulk
-    assert_nil index.instance_variable_get(:@_batch)
-
-    index.bulk do
-      index.index_document '5', color: 'green'
-      index.update_document '5', color: 'blue'
-      index.delete_document '3'
-
-      expected = [
-        {index: {_index: index.alias_name, _type: "widget", _id: "5"}},
-        {color: "green"},
-        {update: {_index: "widgets", _type: "widget", _id: "5", _retry_on_conflict: 3}},
-        {doc: {color: "blue"}, doc_as_upsert: true},
-        {delete: {_index: index.alias_name, _type: "widget", _id: "3", _retry_on_conflict: 3}}
-      ]
-      assert_equal expected, index.current_bulk_batch
-    end
-
-    assert_nil index.current_bulk_batch
-  end
-
-  def test_bulk_error
-    without_deferring(index) do
-      begin
-        index.bulk do
-          index.index_document '5', color: 'green'
-          index.index_document '3', color: {'bad' => 'stuff'}
-        end
-        refute index.record_exists?('3')
-        assert false, 'Expected ElasticRecord::BulkError'
-      rescue => e
-        assert_match '[{"index"', e.message
-      end
-    end
-  end
-
-  def test_bulk_inheritence
-    without_deferring(index) do
-      index.bulk do
-        InheritedWidget.elastic_index.index_document '5', color: 'green'
-
-        expected = [
-          {index: {_index: index.alias_name, _type: "widget", _id: "5"}},
-          {color: "green"}
-        ]
-        assert_equal expected, index.current_bulk_batch
-      end
-    end
   end
 
   private

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,5 +22,12 @@ module MiniTest
         model.elastic_index.reset_deferring!
       end
     end
+
+    def without_deferring(index)
+      index.disable_deferring!
+      yield
+      index.reset
+      index.enable_deferring!
+    end
   end
 end


### PR DESCRIPTION
Extract bulk operations into new `BulkDocuments` module. Some of the methods override methods in `Document`, calling super if not inside a bulk operation.

Further, use `Thread.current` to make bulk operations threadsafe. ElasticRecord is currently not threadsafe because it `Connection#bulk_stack` is a variable on the global instance of connection, which is shared across all threads.
  