### PR TITLE
Object indexing fixups

### DIFF
--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -24,9 +24,9 @@ module ElasticRecord
       value = try field
       return if value.nil?
 
-      value = case mapping[:type]
+      value = case mapping[:type].to_sym
               when :object
-                value.as_search_document
+                value.try(:as_search_document) || value
               when :nested
                 value.map(&:as_search_document)
               else

--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -26,7 +26,7 @@ module ElasticRecord
 
       value = case mapping[:type].to_sym
               when :object
-                value.try(:as_search_document) || value
+                value.respond_to?(:as_search_document) ? value.as_search_document : value
               when :nested
                 value.map(&:as_search_document)
               else

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -39,12 +39,9 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
     end
 
     self.doctype.mapping[:properties].update(
-      author: {
-        type: :object
-      },
-      commenters: {
-        type: :nested
-      }
+      author:     { type: :object },
+      commenters: { type: :nested },
+      meta:       { type: :object }
     )
 
     def author
@@ -54,6 +51,10 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
     def commenters
       [Author.new, Author.new]
     end
+
+    def meta
+      { some: "value" }
+    end
   end
 
   def test_as_search_document_with_special_fields
@@ -61,5 +62,6 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
 
     assert_equal({name: 'Jonny'}, doc[:author])
     assert_equal([{name: 'Jonny'}, {name: 'Jonny'}], doc[:commenters])
+    assert_equal({some: 'value'}, doc[:meta])
   end
 end

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -41,7 +41,7 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
     self.doctype.mapping[:properties].update(
       author:     { type: :object },
       commenters: { type: :nested },
-      meta:       { type: :object }
+      meta:       { type: "object" }
     )
 
     def author


### PR DESCRIPTION
Make symbols vs strings consistent; don't call as_search_document on Hashes