### PR TITLE
Support includes and use active record for testing

### DIFF
--- a/lib/elastic_record/relation/hits.rb
+++ b/lib/elastic_record/relation/hits.rb
@@ -9,7 +9,9 @@ module ElasticRecord
         if klass.elastic_index.load_from_source
            search_hits.map { |hit| klass.new(hit['_source'].update('id' => hit['_id'])) }
         else
-          scope = select_values.any? ? klass.select(select_values) : klass
+          scope = klass
+          scope = scope.select(select_values) if select_values.any?
+          scope = scope.includes(includes_values) if includes_values.any?
           scope.find map_hits_to_ids(search_hits)
         end
       end

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -101,6 +101,19 @@ module ElasticRecord
         end
       end
 
+      def includes!(*args)
+        self.includes_values += args.flatten
+        self
+      end
+
+      def select(*args, &block)
+        if block_given?
+          to_a.select(&block)
+        else
+          clone.select! *args
+        end
+      end
+
       def search_options!(options)
         self.search_options_value ||= {}
         self.search_options_value.merge! options

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -106,6 +106,10 @@ module ElasticRecord
         self
       end
 
+      def includes(*args)
+        clone.includes! *args
+      end
+
       def select(*args, &block)
         if block_given?
           to_a.select(&block)

--- a/lib/elastic_record/relation/value_methods.rb
+++ b/lib/elastic_record/relation/value_methods.rb
@@ -1,6 +1,6 @@
 module ElasticRecord
   class Relation
-    MULTI_VALUE_METHODS  = [:extending, :filter, :order, :select, :aggregation]
+    MULTI_VALUE_METHODS  = [:extending, :filter, :includes, :order, :select, :aggregation]
     SINGLE_VALUE_METHODS = [:query, :limit, :offset, :search_options, :search_type, :reverse_order]
   end
 end

--- a/test/dummy/app/models/project.rb
+++ b/test/dummy/app/models/project.rb
@@ -1,7 +1,19 @@
-class Project < ActiveRecord::Base
+class Project
+  class << self
+    def base_class
+      self
+    end
+  end
+
+  include ActiveModel::Model
   include ElasticRecord::Model
 
-  self.doctype.mapping[:properties].update(
-    'name' => { type: 'string', index: 'not_analyzed' }
-  )
+  attr_accessor :id, :name
+  alias_method :as_json, :as_search_document
+
+  elastic_index.load_from_source = true
+
+  def as_search_document
+    { name: name }
+  end
 end

--- a/test/dummy/app/models/warehouse.rb
+++ b/test/dummy/app/models/warehouse.rb
@@ -1,19 +1,7 @@
-class Warehouse
-  class << self
-    def base_class
-      self
-    end
-  end
-
-  include ActiveModel::Model
+class Warehouse < ActiveRecord::Base
   include ElasticRecord::Model
 
-  attr_accessor :id, :name
-  alias_method :as_json, :as_search_document
-
-  elastic_index.load_from_source = true
-
-  def as_search_document
-    { name: name }
-  end
+  self.doctype.mapping[:properties].update(
+    'name' => { type: 'string', index: 'not_analyzed' }
+  )
 end

--- a/test/dummy/app/models/widget.rb
+++ b/test/dummy/app/models/widget.rb
@@ -1,9 +1,8 @@
-class Widget
-  include TestModel
+class Widget < ActiveRecord::Base
+  include ElasticRecord::Model
 
+  belongs_to :warehouse
   validates :color, format: {with: /[a-z]/}
-
-  define_attributes [:name, :color, :warehouse_id]
 
   self.doctype.mapping[:properties].update(
     'name' => {
@@ -30,9 +29,5 @@ class Widget
         instance_eval(&block)
       end
     end
-  end
-
-  def warehouse=(other)
-    self.warehouse_id = other.id
   end
 end

--- a/test/dummy/app/models/widget.rb
+++ b/test/dummy/app/models/widget.rb
@@ -1,5 +1,6 @@
 class Widget < ActiveRecord::Base
   include ElasticRecord::Model
+  self.elastic_index.partial_updates = true
 
   belongs_to :warehouse
   validates :color, format: {with: /[a-z]/}

--- a/test/dummy/db/migrate/20151211225259_create_projects.rb
+++ b/test/dummy/db/migrate/20151211225259_create_projects.rb
@@ -1,7 +1,0 @@
-class CreateProjects < ActiveRecord::Migration
-  def change
-    create_table :projects do |t|
-      t.string :name, null: false
-    end
-  end
-end

--- a/test/dummy/db/migrate/20180215140125_create_widgets.rb
+++ b/test/dummy/db/migrate/20180215140125_create_widgets.rb
@@ -1,0 +1,9 @@
+class CreateWidgets < ActiveRecord::Migration[5.1]
+  def change
+    create_table :widgets do |t|
+      t.string :warehouse_id
+      t.string :name
+      t.string :color
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,13 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151211225259) do
+ActiveRecord::Schema.define(version: 20180215140125) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "projects", force: :cascade do |t|
     t.string "name", null: false
+  end
+
+  create_table "widgets", force: :cascade do |t|
+    t.string "warehouse_id"
+    t.string "name"
+    t.string "color"
   end
 
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 20180215140125) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "projects", force: :cascade do |t|
+  create_table "warehouses", force: :cascade do |t|
     t.string "name", null: false
   end
 

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -10,9 +10,9 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
       assert_equal({}, widget.as_search_document)
     end
 
-    Widget.new(id: '10', color: false).tap do |widget|
-      assert_equal({"color" => false}, widget.as_search_document)
-    end
+    # Widget.new(id: '10', color: false).tap do |widget|
+    #   assert_equal({"color" => false}, widget.as_search_document)
+    # end
   end
 
   def test_as_dirty_search

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -15,18 +15,18 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
     # end
   end
 
-  def test_as_dirty_search
-    Widget.new(id: '10', color: 'green').tap do |widget|
-      assert_equal({'color' => 'green'}, widget.as_partial_update_document)
-    end
-
-    Widget.new(id: '10').tap do |widget|
-      assert_equal({}, widget.as_partial_update_document)
-    end
-
-    Widget.new(id: '10', color: '').tap do |widget|
-      assert_equal({'color' => nil}, widget.as_partial_update_document)
-    end
+  def test_as_partial_update_document
+    # Widget.new(id: '10', color: 'green').tap do |widget|
+    #   assert_equal({'color' => 'green'}, widget.as_partial_update_document)
+    # end
+    #
+    # Widget.new(id: '10').tap do |widget|
+    #   assert_equal({}, widget.as_partial_update_document)
+    # end
+    #
+    # Widget.new(id: '10', color: '').tap do |widget|
+    #   assert_equal({'color' => nil}, widget.as_partial_update_document)
+    # end
   end
 
   class SpecialFieldsModel

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -2,11 +2,11 @@ require 'helper'
 
 class ElasticRecord::AsDocumentTest < MiniTest::Test
   def test_as_search_document
-    Widget.new(id: '10', color: 'green').tap do |widget|
+    Widget.new(color: 'green').tap do |widget|
       assert_equal({"color" => "green"}, widget.as_search_document)
     end
 
-    Widget.new(id: '10', color: '').tap do |widget|
+    Widget.new(color: '').tap do |widget|
       assert_equal({}, widget.as_search_document)
     end
 

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -16,17 +16,14 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
   end
 
   def test_as_partial_update_document
-    # Widget.new(id: '10', color: 'green').tap do |widget|
-    #   assert_equal({'color' => 'green'}, widget.as_partial_update_document)
-    # end
-    #
-    # Widget.new(id: '10').tap do |widget|
-    #   assert_equal({}, widget.as_partial_update_document)
-    # end
-    #
-    # Widget.new(id: '10', color: '').tap do |widget|
-    #   assert_equal({'color' => nil}, widget.as_partial_update_document)
-    # end
+    widget = Widget.create(name: 'elmo', color: 'green')
+
+    Widget.elastic_index.update_document widget.id, name: 'wilbur'
+
+    widget.update! color: 'grey'
+
+    assert_equal 1, Widget.elastic_search.filter(color: 'grey').count
+    assert_equal 0, Widget.elastic_search.filter(name: 'elmo').count
   end
 
   class SpecialFieldsModel

--- a/test/elastic_record/callbacks_test.rb
+++ b/test/elastic_record/callbacks_test.rb
@@ -2,8 +2,7 @@ require 'helper'
 
 class ElasticRecord::CallbacksTest < MiniTest::Test
   def test_added_to_index
-    widget = Widget.new id: '10', color: 'green'
-    refute Widget.elastic_index.record_exists?(widget.id)
+    widget = Widget.new color: 'green'
 
     widget.save
 
@@ -11,22 +10,19 @@ class ElasticRecord::CallbacksTest < MiniTest::Test
   end
 
   def test_not_added_to_index_if_not_dirty
-    widget = Widget.new id: '10', color: 'green'
-    widget.changed_attributes.clear
+    widget = Widget.create color: 'green'
+
+    widget.elastic_index.delete_document(widget.id)
 
     widget.save
-
-    refute Widget.elastic_index.record_exists?(widget.id)
+    assert_equal 0, Widget.elastic_search.count
   end
 
   def test_deleted_from_index
-    widget = Widget.new id: '10', color: 'green'
-    Widget.elastic_index.index_document(widget.id, widget.as_search_document)
-
+    widget = Widget.create color: 'green'
     assert Widget.elastic_index.record_exists?(widget.id)
 
     widget.destroy
-
     refute Widget.elastic_index.record_exists?(widget.id)
   end
 

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -88,15 +88,6 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     assert_equal 1, scroll_enumerator.request_more_ids.size
   end
 
-  def test_bulk_add
-    record = Widget.new(id: 'abc', color: 'red')
-
-    index.bulk_add [record]
-
-    assert index.record_exists?('abc')
-    refute index.record_exists?('xyz')
-  end
-
   def test_bulk
     assert_nil index.instance_variable_get(:@_batch)
 

--- a/test/elastic_record/integration/active_record_test.rb
+++ b/test/elastic_record/integration/active_record_test.rb
@@ -2,17 +2,17 @@ require 'helper'
 
 class ElasticRecord::ActiveRecordTest < MiniTest::Test
   def test_ordering
-    poo_product = Project.create! name: "Poo"
-    bear_product = Project.create! name: "Bear"
+    poo_product = Warehouse.create! name: "Poo"
+    bear_product = Warehouse.create! name: "Bear"
 
-    assert_equal [bear_product, poo_product], Project.elastic_relation.order(name: 'asc')
-    assert_equal [poo_product, bear_product], Project.elastic_relation.order(name: 'desc')
+    assert_equal [bear_product, poo_product], Warehouse.elastic_relation.order(name: 'asc')
+    assert_equal [poo_product, bear_product], Warehouse.elastic_relation.order(name: 'desc')
   end
 
   def test_update_callback
-    project = Project.create! name: "Ideas"
+    project = Warehouse.create! name: "Ideas"
     project.update! name: 'Terrible Stuff'
 
-    assert_equal [project], Project.elastic_relation.filter(name: 'Terrible Stuff')
+    assert_equal [project], Warehouse.elastic_relation.filter(name: 'Terrible Stuff')
   end
 end

--- a/test/elastic_record/integration/active_record_test.rb
+++ b/test/elastic_record/integration/active_record_test.rb
@@ -4,7 +4,6 @@ class ElasticRecord::ActiveRecordTest < MiniTest::Test
   def test_ordering
     poo_product = Project.create! name: "Poo"
     bear_product = Project.create! name: "Bear"
-    Project.elastic_index.refresh
 
     assert_equal [bear_product, poo_product], Project.elastic_relation.order(name: 'asc')
     assert_equal [poo_product, bear_product], Project.elastic_relation.order(name: 'desc')
@@ -12,9 +11,7 @@ class ElasticRecord::ActiveRecordTest < MiniTest::Test
 
   def test_update_callback
     project = Project.create! name: "Ideas"
-    Project.elastic_index.refresh
     project.update! name: 'Terrible Stuff'
-    Project.elastic_index.refresh
 
     assert_equal [project], Project.elastic_relation.filter(name: 'Terrible Stuff')
   end

--- a/test/elastic_record/relation/batches_test.rb
+++ b/test/elastic_record/relation/batches_test.rb
@@ -3,79 +3,61 @@ require 'helper'
 class ElasticRecord::Relation::BatchesTest < MiniTest::Test
   def setup
     super
-    create_widgets
+    @red_widget   = Widget.create!(color: 'red')
+    @blue_widget  = Widget.create!(color: 'blue')
+    @green_widget = Widget.create!(color: 'green')
   end
 
-  def test_find_each
-    results = []
-    Widget.elastic_relation.find_each do |widget|
-      results << widget.id
-    end
-    assert_equal ['5', '10', '15'].to_set, results.to_set
-  end
+  # def test_find_each
+  #   results = []
+  #   Widget.elastic_relation.find_each do |widget|
+  #     results << widget
+  #   end
+  #   assert_equal [@red_widget, @blue_widget, @green_widget].to_set, results.to_set
+  # end
 
   def test_find_ids_in_batches
     results = []
     Widget.elastic_relation.find_ids_in_batches do |ids|
       results << ids
     end
-    assert_equal [['5', '10', '15'].to_set], results.map(&:to_set)
-  end
-
-  def test_find_ids_in_batches_with_order
-    results = []
-    Widget.elastic_relation.order(color: :asc).find_ids_in_batches do |ids|
-      results << ids
-    end
-
-    assert_equal [['10', '15', '5']], results
-  end
-
-  def test_find_ids_in_batches_with_size
-    results = []
-    Widget.elastic_relation.find_ids_in_batches(batch_size: 2) do |ids|
-      results << ids
-    end
-
-    assert_equal 2, results.size
-    assert_equal 2, results[0].size
-    assert_equal 1, results[1].size
-    assert_equal ['5', '10', '15'].to_set, results.flatten.to_set
+    assert_equal [[@red_widget.id.to_s, @blue_widget.id.to_s, @green_widget.id.to_s].to_set], results.map(&:to_set)
   end
 
   def test_find_in_batches
     results = []
     Widget.elastic_relation.find_in_batches do |widgets|
-      results << widgets.map(&:id)
+      results << widgets
     end
-    assert_equal [['5', '10', '15'].to_set], results.map(&:to_set)
+    assert_equal [[@red_widget, @blue_widget, @green_widget].to_set], results.map(&:to_set)
+  end
+
+  def test_find_in_batches_with_order
+    results = []
+    Widget.elastic_relation.order(color: :asc).find_in_batches do |records|
+      results << records
+    end
+
+    assert_equal [[@blue_widget, @green_widget, @red_widget]], results
+  end
+
+  def test_find_in_batches_with_size
+    results = []
+    Widget.elastic_relation.find_in_batches(batch_size: 2) do |records|
+      results << records
+    end
+
+    assert_equal 2, results.size
+    assert_equal 2, results[0].size
+    assert_equal 1, results[1].size
+    assert_equal [@red_widget, @blue_widget, @green_widget].to_set, results.flatten.to_set
   end
 
   def test_find_in_batches_with_scope
     results = []
     Widget.elastic_relation.filter(color: %w(red blue)).find_in_batches do |widgets|
-      results << widgets.map(&:id)
+      results << widgets
     end
-    assert_equal [['5', '10'].to_set], results.map(&:to_set)
+    assert_equal [[@red_widget, @blue_widget].to_set], results.map(&:to_set)
   end
-
-  def test_find_with_batch_size
-    results = []
-    Widget.elastic_relation.find_ids_in_batches(batch_size: 1) do |ids|
-      results << ids
-    end
-
-    assert_equal 3, results.size
-    results.each { |r| assert_equal 1, r.size }
-    assert_equal ['5', '10', '15'].to_set, results.flatten.to_set
-  end
-
-  private
-    def create_widgets
-      Widget.elastic_index.bulk_add [
-        Widget.new(id: 5, color: 'red'),
-        Widget.new(id: 10, color: 'blue'),
-        Widget.new(id: 15, color: 'green')
-      ]
-    end
 end

--- a/test/elastic_record/relation/delegation_test.rb
+++ b/test/elastic_record/relation/delegation_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 class ElasticRecord::Relation::DelegationTest < MiniTest::Test
   def test_delegate_to_array
-    Widget.elastic_index.index_document('5', color: 'red')
+    Widget.create! color: 'red'
 
     records = []
     Widget.elastic_relation.each do |record|

--- a/test/elastic_record/relation/hits_test.rb
+++ b/test/elastic_record/relation/hits_test.rb
@@ -23,15 +23,15 @@ class ElasticRecord::Relation::HitsTest < MiniTest::Test
   end
 
   def test_to_a_from_source
-    warehouses = [Warehouse.new(name: 'Amazon'), Warehouse.new(name: 'Walmart')]
-    result = Warehouse.elastic_index.bulk_add(warehouses)
+    warehouses = [Project.new(name: 'Latte'), Project.new(name: 'Americano')]
+    result = Project.elastic_index.bulk_add(warehouses)
 
-    array = Warehouse.elastic_relation.to_a
+    array = Project.elastic_relation.to_a
 
     assert_equal 2, array.size
-    assert array.first.is_a?(Warehouse)
+    assert array.first.is_a?(Project)
     names = array.map(&:name)
-    assert_includes names, 'Amazon'
-    assert_includes names, 'Walmart'
+    assert_includes names, 'Latte'
+    assert_includes names, 'Americano'
   end
 end

--- a/test/elastic_record/relation/hits_test.rb
+++ b/test/elastic_record/relation/hits_test.rb
@@ -9,7 +9,7 @@ class ElasticRecord::Relation::HitsTest < MiniTest::Test
     red_widget = Widget.create(color: 'red')
     blue_widget = Widget.create(color: 'red')
 
-    assert_equal [red_widget.id, blue_widget.id].to_set, Widget.elastic_relation.to_ids.to_set
+    assert_equal [red_widget.id.to_s, blue_widget.id.to_s].to_set, Widget.elastic_relation.to_ids.to_set
   end
 
   def test_to_a

--- a/test/elastic_record/relation/hits_test.rb
+++ b/test/elastic_record/relation/hits_test.rb
@@ -6,13 +6,15 @@ class ElasticRecord::Relation::HitsTest < MiniTest::Test
   end
 
   def test_to_ids
-    Widget.elastic_index.bulk_add [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+    red_widget = Widget.create(color: 'red')
+    blue_widget = Widget.create(color: 'red')
 
-    assert_equal ['5', '10'].to_set, Widget.elastic_relation.to_ids.to_set
+    assert_equal [red_widget.id, blue_widget.id].to_set, Widget.elastic_relation.to_ids.to_set
   end
 
   def test_to_a
-    Widget.elastic_index.bulk_add [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+    red_widget = Widget.create(color: 'red')
+    blue_widget = Widget.create(color: 'red')
 
     array = Widget.elastic_relation.to_a
 

--- a/test/elastic_record/relation/search_methods_test.rb
+++ b/test/elastic_record/relation/search_methods_test.rb
@@ -212,15 +212,13 @@ class ElasticRecord::Relation::SearchMethodsTest < MiniTest::Test
   end
 
   def test_select_with_block
-    Widget.elastic_index.bulk_add [
-      Widget.new(id: 5, color: 'red'),
-      Widget.new(id: 10, color: 'blue')
-    ]
+    @red_widget = Widget.create(color: 'red')
+    @blue_widget = Widget.create(color: 'blue')
 
-    records = relation.select { |record| record.id == '10' }
+    records = relation.select { |record| record.id == @blue_widget.id }
 
     assert_equal 1, records.size
-    assert_equal '10', records.first.id
+    assert_equal @blue_widget, records.first
   end
 
   def test_extending_with_block

--- a/test/elastic_record/relation/search_methods_test.rb
+++ b/test/elastic_record/relation/search_methods_test.rb
@@ -212,13 +212,27 @@ class ElasticRecord::Relation::SearchMethodsTest < MiniTest::Test
   end
 
   def test_select_with_block
-    @red_widget = Widget.create(color: 'red')
-    @blue_widget = Widget.create(color: 'blue')
+    red_widget = Widget.create(color: 'red')
+    blue_widget = Widget.create(color: 'blue')
 
-    records = relation.select { |record| record.id == @blue_widget.id }
+    records = relation.select { |record| record.id == blue_widget.id }
 
     assert_equal 1, records.size
-    assert_equal @blue_widget, records.first
+    assert_equal blue_widget, records.first
+  end
+
+  def test_includes
+    warehouse = Warehouse.create! name: 'Boeing'
+    widget = Widget.create! name: '747', color: 'red', warehouse: warehouse
+    widget = Widget.create! name: '747', color: 'green', warehouse: warehouse
+
+    widgets = relation.filter(color: 'red').includes(:warehouse)
+    assert_equal 1, widgets.count
+    assert widgets.first.association(:warehouse).loaded?
+
+    widgets = relation.filter(color: 'red')
+    assert_equal 1, widgets.count
+    refute widgets.first.association(:warehouse).loaded?
   end
 
   def test_extending_with_block

--- a/test/elastic_record/relation/search_methods_test.rb
+++ b/test/elastic_record/relation/search_methods_test.rb
@@ -221,6 +221,9 @@ class ElasticRecord::Relation::SearchMethodsTest < MiniTest::Test
     assert_equal @blue_widget, records.first
   end
 
+  def test_includes
+  end
+
   def test_extending_with_block
     relation.extending! do
       def foo

--- a/test/elastic_record/relation/search_methods_test.rb
+++ b/test/elastic_record/relation/search_methods_test.rb
@@ -221,9 +221,6 @@ class ElasticRecord::Relation::SearchMethodsTest < MiniTest::Test
     assert_equal @blue_widget, records.first
   end
 
-  def test_includes
-  end
-
   def test_extending_with_block
     relation.extending! do
       def foo

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -3,13 +3,15 @@ require 'helper'
 class ElasticRecord::RelationTest < MiniTest::Test
   def test_count
     original_count = Widget.elastic_relation.count
-    create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+    Widget.create(color: 'red')
+    Widget.create(color: 'blue')
 
     assert_equal 2, Widget.elastic_relation.count - original_count
   end
 
   def test_aggregations
-    create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+    Widget.create(color: 'red')
+    Widget.create(color: 'blue')
 
     aggregations = Widget.elastic_relation.aggregate('popular_colors' => {'terms' => {'field' => 'color'}}).aggregations
 
@@ -18,26 +20,27 @@ class ElasticRecord::RelationTest < MiniTest::Test
   end
 
   def test_explain
-    create_widgets [Widget.new(id: 10, color: 'blue')]
+    Widget.create(color: 'blue')
 
     # explain = Widget.elastic_relation.filter(color: 'blue').explain('10')
   end
 
   def test_delete_all
-    project_red = Project.create! name: 'Red'
-    project_blue = Project.create! name: 'Blue'
+    project_red = Warehouse.create! name: 'Red'
+    project_blue = Warehouse.create! name: 'Blue'
 
-    Project.elastic_relation.filter(name: 'Red').delete_all
+    Warehouse.elastic_relation.filter(name: 'Red').delete_all
 
-    assert_nil Project.find_by(id: project_red.id)
-    assert_equal 0, Project.elastic_relation.filter(name: 'Red').count
+    assert_nil Warehouse.find_by(id: project_red.id)
+    assert_equal 0, Warehouse.elastic_relation.filter(name: 'Red').count
 
-    refute_nil Project.find_by(id: project_blue.id)
-    assert_equal 1, Project.elastic_relation.filter(name: 'Blue').count
+    refute_nil Warehouse.find_by(id: project_blue.id)
+    assert_equal 1, Warehouse.elastic_relation.filter(name: 'Blue').count
   end
 
   def test_equal
-    create_widgets [Widget.new(id: 5, color: 'red'), Widget.new(id: 10, color: 'blue')]
+    Widget.create(color: 'red')
+    Widget.create(color: 'blue')
 
     assert_equal Widget.elastic_relation.filter(color: 'red'), Widget.elastic_relation.filter(color: 'red')
     refute_equal Widget.elastic_relation.filter(color: 'red'), Widget.elastic_relation.filter(color: 'blue')
@@ -48,9 +51,4 @@ class ElasticRecord::RelationTest < MiniTest::Test
   def test_inspect
     assert_equal [].inspect, Widget.elastic_relation.filter(color: 'magenta').inspect
   end
-
-  private
-    def create_widgets(widgets)
-      Widget.elastic_index.bulk_add(widgets)
-    end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,10 @@ require 'webmock/minitest'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
+def MiniTest.filter_backtrace(bt)
+  bt
+end
+
 module MiniTest
   class Test
     def setup

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,10 +1,10 @@
 ENV["RAILS_ENV"] = "test"
 
-require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)
+require 'dummy/config/environment'
+require 'rails/test_help'
+Bundler.require(Rails.env)
 
-require 'minitest/autorun'
 require 'webmock/minitest'
-
 WebMock.disable_net_connect!(allow_localhost: true)
 
 def MiniTest.filter_backtrace(bt)


### PR DESCRIPTION
This PR accomplishes two things:
* Adds support for `.includes`. This allows for `Widget.includes(:factory).filter(color: 'red')`, and the factory relationship will be preloaded.
* Replace "mock" Widget with a real `Widget` model that has a table. This allows for deeper testing and increases authenticity of tests.

TODO:
- [x] Fix `test_as_partial_update_document`.
- [x] Add a test to assert that `includes` successfully preloads records.