### PR TITLE
ES6 Upgrade 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ sudo: required
 dist: trusty
 before_install:
 - echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
-- sudo apt-get install elasticsearch
-- sudo service elasticsearch start; sleep 10
+- sudo apt-get update && sudo apt-get install -y elasticsearch
+- sudo service elasticsearch start
 before_script:
 - cp test/dummy/.env.example test/dummy/.env
-- curl localhost:9200
+- until ping -c1 http://localhost:9200 &>/dev/null; do :; done
 - bundle exec rake app:db:setup
 - bundle exec rake app:index:reset
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 rvm: 2.4.1
 cache: bundler
-sudo: false
+sudo: required
 dist: trusty
 before_install:
 - echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ dist: trusty
 before_install:
 - echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
 - sudo apt-get install elasticsearch
+- sudo service elasticsearch start
 before_script:
 - cp test/dummy/.env.example test/dummy/.env
 - curl localhost:9200
 - bundle exec rake app:db:setup
 - bundle exec rake app:index:reset
 services:
-- elasticsearch
 - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 before_install:
 - echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
 - sudo apt-get install elasticsearch
-- sudo service elasticsearch start
+- sudo service elasticsearch start; sleep 10
 before_script:
 - cp test/dummy/.env.example test/dummy/.env
 - curl localhost:9200

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ before_install:
 - wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
 - echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
 - sudo apt-get update && sudo apt-get install -y elasticsearch
-- sudo service elasticsearch start
+- sudo service elasticsearch start; sleep 10
 before_script:
 - cp test/dummy/.env.example test/dummy/.env
-- until ping -c1 http://localhost:9200 &>/dev/null; do :; done
+- curl http://localhost:9200
 - bundle exec rake app:db:setup
 - bundle exec rake app:index:reset
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ rvm: 2.4.1
 cache: bundler
 sudo: false
 dist: trusty
-addons:
-  apt:
-    sources:
-    - elasticsearch-6.2
-    packages:
-    - elasticsearch
+before_install:
+- echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
+- sudo apt-get install elasticsearch
 before_script:
 - cp test/dummy/.env.example test/dummy/.env
 - curl localhost:9200

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: bundler
 sudo: required
 dist: trusty
 before_install:
+- wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
 - echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
 - sudo apt-get update && sudo apt-get install -y elasticsearch
 - sudo service elasticsearch start

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 addons:
   apt:
     sources:
-    - elasticsearch-6.x
+    - elasticsearch-6.2
     packages:
     - elasticsearch
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 addons:
   apt:
     sources:
-    - elasticsearch-5.x
+    - elasticsearch-6.x
     packages:
     - elasticsearch
 before_script:

--- a/lib/elastic_record/doctype.rb
+++ b/lib/elastic_record/doctype.rb
@@ -10,6 +10,12 @@ module ElasticRecord
       }
     }
 
+    PERCOLATOR_MAPPING = {
+      properties: {
+        query: { type: 'percolator' }
+      }
+    }
+
     def initialize(name, mapping = DEFAULT_MAPPING.deep_dup)
       @name = name
       @mapping = mapping

--- a/lib/elastic_record/doctype.rb
+++ b/lib/elastic_record/doctype.rb
@@ -10,18 +10,6 @@ module ElasticRecord
       }
     }
 
-    PERCOLATOR_MAPPING = {
-      properties: {
-        query: {
-          type: "percolator"
-        }
-      }
-    }
-
-    def self.percolator_doctype
-      new('queries', PERCOLATOR_MAPPING)
-    end
-
     def initialize(name, mapping = DEFAULT_MAPPING.deep_dup)
       @name = name
       @mapping = mapping

--- a/lib/elastic_record/doctype.rb
+++ b/lib/elastic_record/doctype.rb
@@ -18,12 +18,12 @@ module ElasticRecord
 
     def initialize(name, mapping = DEFAULT_MAPPING.deep_dup)
       @name = name
-      @mapping = mapping
+      @mapping = mapping.deep_symbolize_keys
       @analysis = {}
     end
 
     def mapping=(custom_mapping)
-      mapping.deep_merge!(custom_mapping)
+      mapping.deep_merge!(custom_mapping.deep_symbolize_keys)
     end
 
     def analysis=(custom_analysis)

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -32,17 +32,16 @@ module ElasticRecord
     include Analyze
     include Deferred
 
-    attr_accessor :doctypes
+    attr_accessor :doctype
 
     attr_accessor :disabled
     attr_accessor :model
     attr_accessor :partial_updates
     attr_accessor :load_from_source
 
-    def initialize(models)
-      models = Array.wrap(models)
-      @model = models.first
-      @doctypes = models.map(&:doctype)
+    def initialize(model)
+      @model = model
+      @doctype = model.doctype
       @disabled = false
       @load_from_source = false
     end

--- a/lib/elastic_record/index/mapping.rb
+++ b/lib/elastic_record/index/mapping.rb
@@ -2,7 +2,7 @@ module ElasticRecord
   class Index
     module Mapping
       def update_mapping(index_name = alias_name)
-        connection.json_put "/#{index_name}/_mapping", mapping_body
+        connection.json_put "/#{index_name}/_mapping/#{doctype.name}", mapping_body
       end
 
       def get_mapping(index_name = alias_name)

--- a/lib/elastic_record/index/mapping.rb
+++ b/lib/elastic_record/index/mapping.rb
@@ -14,9 +14,7 @@ module ElasticRecord
       end
 
       def mapping_body
-        doctypes.each_with_object({}) do |doctype, result|
-          result[doctype.name] = doctype.mapping
-        end
+        { doctype.name => doctype.mapping }
       end
     end
   end

--- a/lib/elastic_record/index/settings.rb
+++ b/lib/elastic_record/index/settings.rb
@@ -23,9 +23,7 @@ module ElasticRecord
       end
 
       def analysis_body
-        doctypes.each_with_object({}) do |doctype, result|
-          result.deep_merge!(doctype.analysis)
-        end
+        doctype.analysis
       end
     end
   end

--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -13,7 +13,7 @@ module ElasticRecord
       def elastic_index
         @elastic_index ||=
           begin
-            index = ElasticRecord::Index.new(percolates_model)
+            index = ElasticRecord::Index.new(self)
             index.partial_updates = false
             index
           end

--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -19,6 +19,15 @@ module ElasticRecord
           end
       end
 
+      def doctype
+        @doctype ||=
+          begin
+            dt = Doctype.new(base_class.name.demodulize.underscore)
+            dt.mapping = Doctype::PERCOLATOR_MAPPING
+            dt
+          end
+      end
+
       def percolate(document)
         query = {
           "percolate" => {

--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -19,15 +19,10 @@ module ElasticRecord
           end
       end
 
-      def doctype
-        @doctype ||= Doctype.percolator_doctype
-      end
-
       def percolate(document)
         query = {
           "percolate" => {
             "field"         => "query",
-            "document_type" => percolates_model.doctype.name,
             "document"      => document
           }
         }

--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -22,9 +22,9 @@ module ElasticRecord
       def doctype
         @doctype ||=
           begin
-            dt = Doctype.new(base_class.name.demodulize.underscore)
-            dt.mapping = Doctype::PERCOLATOR_MAPPING
-            dt
+            percolator_doctype = Doctype.new(base_class.name.demodulize.underscore, Doctype::PERCOLATOR_MAPPING)
+            percolator_doctype.mapping = percolates_model.doctype.mapping
+            percolator_doctype
           end
       end
 

--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -13,7 +13,7 @@ module ElasticRecord
       def elastic_index
         @elastic_index ||=
           begin
-            index = ElasticRecord::Index.new([self, percolates_model])
+            index = ElasticRecord::Index.new(percolates_model)
             index.partial_updates = false
             index
           end

--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -23,6 +23,7 @@ module ElasticRecord
         @doctype ||=
           begin
             percolator_doctype = Doctype.new(base_class.name.demodulize.underscore, Doctype::PERCOLATOR_MAPPING)
+            percolator_doctype.analysis = percolates_model.doctype.analysis
             percolator_doctype.mapping = percolates_model.doctype.mapping
             percolator_doctype
           end

--- a/test/dummy/app/models/warehouse.rb
+++ b/test/dummy/app/models/warehouse.rb
@@ -2,6 +2,6 @@ class Warehouse < ActiveRecord::Base
   include ElasticRecord::Model
 
   self.doctype.mapping[:properties].update(
-    'name' => { type: 'string', index: 'not_analyzed' }
+    'name' => { type: 'text', index: false }
   )
 end

--- a/test/dummy/app/models/warehouse.rb
+++ b/test/dummy/app/models/warehouse.rb
@@ -2,6 +2,6 @@ class Warehouse < ActiveRecord::Base
   include ElasticRecord::Model
 
   self.doctype.mapping[:properties].update(
-    'name' => { type: 'text', index: false }
+    'name' => { type: 'keyword' }
   )
 end

--- a/test/dummy/app/models/widget.rb
+++ b/test/dummy/app/models/widget.rb
@@ -8,6 +8,9 @@ class Widget < ActiveRecord::Base
   self.doctype.mapping[:properties].update(
     'name' => {
       type: 'text',
+      fields: {
+        raw: { type: 'keyword' }
+      }
     },
     'color' => {
       type: 'keyword'

--- a/test/dummy/app/models/widget.rb
+++ b/test/dummy/app/models/widget.rb
@@ -7,16 +7,13 @@ class Widget < ActiveRecord::Base
 
   self.doctype.mapping[:properties].update(
     'name' => {
-      type: 'text', index: false,
-      fields: {
-        analyzed: {type: 'text', index: true}
-      }
+      type: 'text',
     },
     'color' => {
-      type: 'text', index: false
+      type: 'keyword'
     },
     'warehouse_id' => {
-      type: 'text', index: false
+      type: 'keyword'
     }
   )
 

--- a/test/dummy/app/models/widget.rb
+++ b/test/dummy/app/models/widget.rb
@@ -7,16 +7,16 @@ class Widget < ActiveRecord::Base
 
   self.doctype.mapping[:properties].update(
     'name' => {
-      type: 'string', index: 'not_analyzed',
+      type: 'text', index: false,
       fields: {
-        analyzed: {type: 'string', index: 'analyzed'}
+        analyzed: {type: 'text', index: true}
       }
     },
     'color' => {
-      type: 'string', index: 'not_analyzed'
+      type: 'text', index: false
     },
     'warehouse_id' => {
-      type: 'string', index: 'not_analyzed'
+      type: 'text', index: false
     }
   )
 

--- a/test/dummy/app/models/widget_query.rb
+++ b/test/dummy/app/models/widget_query.rb
@@ -8,8 +8,7 @@ class WidgetQuery
   doctype.mapping = {
     properties: {
       name: { type: 'keyword' },
-      color: { type: 'keyword' },
-      query: { type: 'percolator' }
+      color: { type: 'keyword' }
     }
   }
 

--- a/test/dummy/app/models/widget_query.rb
+++ b/test/dummy/app/models/widget_query.rb
@@ -5,13 +5,6 @@ class WidgetQuery
 
   self.percolates_model = Widget
 
-  doctype.mapping = {
-    properties: {
-      name: { type: 'keyword' },
-      color: { type: 'keyword' }
-    }
-  }
-
   def as_search_document
     filters = {}
     filters[:name] = name if name

--- a/test/dummy/app/models/widget_query.rb
+++ b/test/dummy/app/models/widget_query.rb
@@ -5,6 +5,14 @@ class WidgetQuery
 
   self.percolates_model = Widget
 
+  doctype.mapping = {
+    properties: {
+      name: { type: 'keyword' },
+      color: { type: 'keyword' },
+      query: { type: 'percolator' }
+    }
+  }
+
   def as_search_document
     filters = {}
     filters[:name] = name if name

--- a/test/elastic_record/doctype_test.rb
+++ b/test/elastic_record/doctype_test.rb
@@ -35,11 +35,4 @@ class ElasticRecord::DoctypeTest < MiniTest::Test
 
     assert_equal expected, doctype.mapping
   end
-
-  def test_percolator_doctype
-    doctype = ElasticRecord::Doctype.percolator_doctype
-
-    assert_equal 'queries', doctype.name
-    assert_equal ElasticRecord::Doctype::PERCOLATOR_MAPPING, doctype.mapping
-  end
 end

--- a/test/elastic_record/index/mapping_test.rb
+++ b/test/elastic_record/index/mapping_test.rb
@@ -8,7 +8,10 @@ class ElasticRecord::Index::MappingTest < MiniTest::Test
         "properties" => {
           "color" => { "type" => "keyword" },
           "name" => {
-            "type" => "text"
+            "type" => "text",
+            "fields" => {
+              "raw" => { "type" => "keyword" }
+            }
           },
           "warehouse_id" => { "type" => "keyword" }
         }

--- a/test/elastic_record/index/mapping_test.rb
+++ b/test/elastic_record/index/mapping_test.rb
@@ -8,8 +8,7 @@ class ElasticRecord::Index::MappingTest < MiniTest::Test
         "properties" => {
           "color" => { "type" => "keyword" },
           "name" => {
-            "type" => "keyword",
-            "fields" => { "analyzed" => { "type" => "text" } }
+            "type" => "text"
           },
           "warehouse_id" => { "type" => "keyword" }
         }

--- a/test/elastic_record/index_test.rb
+++ b/test/elastic_record/index_test.rb
@@ -8,7 +8,7 @@ class ElasticRecord::IndexTest < MiniTest::Test
   end
 
   def test_doctype
-    assert_equal [Widget.doctype], index.doctype
+    assert_equal Widget.doctype, index.doctype
   end
 
   def test_alias_name

--- a/test/elastic_record/index_test.rb
+++ b/test/elastic_record/index_test.rb
@@ -7,8 +7,8 @@ class ElasticRecord::IndexTest < MiniTest::Test
     refute_equal copied.settings.object_id, index.settings.object_id
   end
 
-  def test_doctypes
-    assert_equal [Widget.doctype], index.doctypes
+  def test_doctype
+    assert_equal [Widget.doctype], index.doctype
   end
 
   def test_alias_name

--- a/test/elastic_record/percolator_model_test.rb
+++ b/test/elastic_record/percolator_model_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 class ElasticRecord::PercolatorModelTest < MiniTest::Test
   def test_elastic_index
-    assert_equal [WidgetQuery.doctype, Widget.doctype], index.doctype
+    assert_equal WidgetQuery.doctype, index.doctype
     refute index.partial_updates
     assert_equal({}, index.settings)
   end

--- a/test/elastic_record/percolator_model_test.rb
+++ b/test/elastic_record/percolator_model_test.rb
@@ -7,10 +7,6 @@ class ElasticRecord::PercolatorModelTest < MiniTest::Test
     assert_equal({}, index.settings)
   end
 
-  def test_doctype
-    assert_equal ElasticRecord::Doctype.percolator_doctype, WidgetQuery.doctype
-  end
-
   def test_as_search_document
     query = WidgetQuery.new(name: 'foo', color: 'red')
 

--- a/test/elastic_record/percolator_model_test.rb
+++ b/test/elastic_record/percolator_model_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 class ElasticRecord::PercolatorModelTest < MiniTest::Test
   def test_elastic_index
-    assert_equal [WidgetQuery.doctype, Widget.doctype], index.doctypes
+    assert_equal [WidgetQuery.doctype, Widget.doctype], index.doctype
     refute index.partial_updates
     assert_equal({}, index.settings)
   end


### PR DESCRIPTION
Current state of the ES6 upgrade changes. Primarily addresses [removal of mapping types](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html).

- [x] Additional minor changes still need to be looked over and determined if any additional code tweaks are needed (there is a [long list](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-6.0.html#_also_see)).