### PR TITLE
[WIP] ES6 Compatibility Upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,22 @@ rvm: 2.4.1
 cache: bundler
 sudo: false
 dist: trusty
-addons:
-  apt:
-    sources:
-    - elasticsearch-5.x
-    packages:
-    - elasticsearch
+
+before_install:
+- wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+- tar -xzf elasticsearch-${ES_VERSION}.tar.gz
+- ./elasticsearch-${ES_VERSION}/bin/elasticsearch -d
+
 before_script:
 - cp test/dummy/.env.example test/dummy/.env
-- curl localhost:9200
+- wget --quiet --waitretry=1 --retry-connrefused --timeout=20 -O - http://127.0.0.1:9200
 - bundle exec rake app:db:setup
 - bundle exec rake app:index:reset
+
+env:
+  matrix:
+  - ES_VERSION=5.6.7
+  - ES_VERSION=6.2.3
+
 services:
-- elasticsearch
 - postgresql

--- a/lib/elastic_record/doctype.rb
+++ b/lib/elastic_record/doctype.rb
@@ -18,10 +18,6 @@ module ElasticRecord
       }
     }
 
-    def self.percolator_doctype
-      new('queries', PERCOLATOR_MAPPING)
-    end
-
     def initialize(name, mapping = DEFAULT_MAPPING.deep_dup)
       @name = name
       @mapping = mapping

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -141,6 +141,10 @@ module ElasticRecord
         get(id, model.doctype)['found']
       end
 
+      def multiple_doctypes?
+        get_mapping.keys.count > 1
+      end
+
       def search(elastic_query, options = {})
         url = "_search"
         if options.any?

--- a/lib/elastic_record/index/manage.rb
+++ b/lib/elastic_record/index/manage.rb
@@ -76,7 +76,7 @@ module ElasticRecord
       end
 
       def all_names
-        connection.json_get("/#{alias_name}/_mapping/#{model.doctype.name}/").keys
+        connection.json_get("/#{alias_name}/_mapping").keys
       rescue
         # TODO: In ES 1.4, this returns empty rather than a 404
         []

--- a/lib/elastic_record/index/mapping.rb
+++ b/lib/elastic_record/index/mapping.rb
@@ -14,9 +14,11 @@ module ElasticRecord
       end
 
       def mapping_body
-        doctypes.each_with_object({}) do |doctype, result|
-          result[doctype.name] = doctype.mapping
+        mapping = doctypes.each_with_object({}) do |doctype, result|
+          result.deep_merge! doctype.mapping
         end
+
+        { model.doctype.name.to_sym => mapping }
       end
     end
   end

--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -27,7 +27,7 @@ module ElasticRecord
         query = {
           "percolate" => {
             "field"         => "query",
-            "document_type" => percolates_model.doctype.name,
+            "document_type" => doctype.name,
             "document"      => document
           }
         }

--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -20,14 +20,14 @@ module ElasticRecord
       end
 
       def doctype
-        @doctype ||= Doctype.percolator_doctype
+        @doctype ||= Doctype.new(percolates_model.doctype.name, Doctype::PERCOLATOR_MAPPING)
       end
 
       def percolate(document)
         query = {
           "percolate" => {
             "field"         => "query",
-            "document_type" => doctype.name,
+            "document_type" => percolates_model.doctype.name,
             "document"      => document
           }
         }

--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -20,7 +20,11 @@ module ElasticRecord
       end
 
       def doctype
-        @doctype ||= Doctype.new(percolates_model.doctype.name, Doctype::PERCOLATOR_MAPPING)
+        @doctype ||=
+          begin
+            doctype_name = check_mapped_doctype_name || percolates_model.doctype.name
+            Doctype.new(doctype_name, Doctype::PERCOLATOR_MAPPING)
+          end
       end
 
       def percolate(document)
@@ -34,6 +38,26 @@ module ElasticRecord
 
         elastic_search.filter(query).limit(5000)
       end
+
+      private
+
+        def check_mapped_doctype_name
+          mapped_doctypes = elastic_connection.json_get("/#{base_class.name.demodulize.underscore.pluralize}/_mapping").values.first['mappings']
+
+          if mapped_doctypes.keys.count > 1
+            mapped_percolator_doctype(mapped_doctypes)
+          end
+        rescue ElasticRecord::ConnectionError
+          nil
+        end
+
+        def mapped_percolator_doctype(doctypes_map)
+          doctypes_map.each_pair do |doctype_name, mapping|
+            mapping['properties'].each_value do |value|
+              return doctype_name if value == {"type" => "percolator"}
+            end
+          end
+        end
     end
   end
 end

--- a/test/elastic_record/doctype_test.rb
+++ b/test/elastic_record/doctype_test.rb
@@ -37,9 +37,9 @@ class ElasticRecord::DoctypeTest < MiniTest::Test
   end
 
   def test_percolator_doctype
-    doctype = ElasticRecord::Doctype.percolator_doctype
+    doctype = WidgetQuery.doctype
 
-    assert_equal 'queries', doctype.name
+    assert_equal WidgetQuery.percolates_model.doctype.name, doctype.name
     assert_equal ElasticRecord::Doctype::PERCOLATOR_MAPPING, doctype.mapping
   end
 end

--- a/test/elastic_record/doctype_test.rb
+++ b/test/elastic_record/doctype_test.rb
@@ -39,6 +39,8 @@ class ElasticRecord::DoctypeTest < MiniTest::Test
   def test_percolator_doctype
     doctype = WidgetQuery.doctype
 
+    skip if WidgetQuery.elastic_index.multiple_doctypes?
+
     assert_equal WidgetQuery.percolates_model.doctype.name, doctype.name
     assert_equal ElasticRecord::Doctype::PERCOLATOR_MAPPING, doctype.mapping
   end

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -138,6 +138,12 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     end
   end
 
+  def test_has_single_doctype
+    without_deferring(index) do
+      refute index.multiple_doctypes?
+    end
+  end
+
   private
 
     def without_deferring(index)

--- a/test/elastic_record/percolator_model_test.rb
+++ b/test/elastic_record/percolator_model_test.rb
@@ -8,7 +8,7 @@ class ElasticRecord::PercolatorModelTest < MiniTest::Test
   end
 
   def test_doctype
-    assert_equal ElasticRecord::Doctype.percolator_doctype, WidgetQuery.doctype
+    assert_equal ElasticRecord::Doctype::PERCOLATOR_MAPPING, WidgetQuery.doctype.mapping
   end
 
   def test_as_search_document


### PR DESCRIPTION
The primary change here is how `mapping_body` behaves. Both ES5 and ES6 versions will now us a single doctype mapping strategy, regardless if multiple models were used to initialize the index. Since both versions support this, the approach alleviates the need have the `doctype.name` be dynamic depending on the ES version.

As an alternative, the mapping also adds a `custom_doctype` field to the mapping which would allow implementations to filter results by a doctype if multiple models share the same index. However, models are not automatically index with the `custom_doctype` set appropriately...I was struggling to get this working properly.

Ideally, I think we'd want something like this to be possible:

```ruby
ElasticRecord::Index.new([Widget, Product]).create_and_deploy

Widget.create color: 'red'
Product.create color: 'red'

Widget.elastic_search.filter(color: 'red').count # only returns one result -- document with custom_doctype == 'widget' and 'color' == red

Widget.elastic_index == Product.elastic_index # also should have the same index reference
```

When attempting to get the above working, I ran into some issues and am still investigating.