### PR TITLE
When nesting bulk blocks, always defer to the outermost one

### DIFF
--- a/lib/elastic_record/connection.rb
+++ b/lib/elastic_record/connection.rb
@@ -5,7 +5,7 @@ module ElasticRecord
     attr_accessor :servers, :options
     attr_accessor :request_count, :current_server
     attr_accessor :max_request_count
-    attr_accessor :bulk_stack
+    attr_accessor :bulk_actions
     def initialize(servers, options = {})
       self.servers = Array(servers)
 
@@ -14,7 +14,7 @@ module ElasticRecord
       self.request_count      = 0
       self.max_request_count  = 100
       self.options            = options.symbolize_keys
-      self.bulk_stack         = []
+      self.bulk_actions       = nil
     end
 
     def head(path)

--- a/lib/elastic_record/index/deferred.rb
+++ b/lib/elastic_record/index/deferred.rb
@@ -11,11 +11,11 @@ module ElasticRecord
         attr_accessor :index
         attr_accessor :deferred_actions
         attr_accessor :writes_made
-        attr_accessor :bulk_stack
+        attr_accessor :bulk_actions
 
         def initialize(index)
           @index = index
-          @bulk_stack = []
+          @bulk_actions = nil
           reset!
         end
 

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -164,7 +164,8 @@ module ElasticRecord
       end
 
       def bulk(options = {})
-        connection.bulk_stack.push []
+        return if current_bulk_batch
+        connection.bulk_actions = []
 
         yield
 
@@ -174,7 +175,7 @@ module ElasticRecord
           verify_bulk_results(results)
         end
       ensure
-        connection.bulk_stack.pop
+        connection.bulk_actions = nil
       end
 
       def bulk_add(batch, index_name: alias_name)
@@ -186,7 +187,7 @@ module ElasticRecord
       end
 
       def current_bulk_batch
-        connection.bulk_stack.last
+        connection.bulk_actions
       end
 
       private

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -89,7 +89,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
   end
 
   def test_bulk
-    assert_nil index.instance_variable_get(:@_batch)
+    assert_nil index.current_bulk_batch
 
     index.bulk do
       index.index_document '5', color: 'green'
@@ -107,6 +107,28 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     end
 
     assert_nil index.current_bulk_batch
+  end
+
+  def test_bulk_nested
+    expected_warehouse_count = Warehouse.count
+
+    begin
+      Warehouse.elastic_index.bulk do
+        Warehouse.transaction do
+          Warehouse.elastic_index.bulk do
+            Warehouse.transaction do
+              Warehouse.create(name: 'Warehouse 13')
+            end
+          end
+
+          Warehouse.create(name: nil)
+        end
+      end
+    rescue ActiveRecord::NotNullViolation
+    end
+
+    assert_equal 0, Warehouse.elastic_relation.count
+    assert_equal expected_warehouse_count, Warehouse.count
   end
 
   def test_bulk_error


### PR DESCRIPTION
This is mostly Matt's code but he went 🚵 

This fixes the case where you nest ElasticRecord bulk "transactions" and ActiveRecord transactions inside of itself, and there's an exception in the inner set of blocks. See the `test_bulk_nested` case for an example.