### PR TITLE
[WIP] Respect explicitly-defined object mappings

### DIFF
--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -29,6 +29,8 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
   class SpecialFieldsModel
     include TestModel
 
+    attr_accessor :details
+
     class Author
       def as_search_document
         {name: 'Jonny'}
@@ -38,7 +40,12 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
     self.doctype.mapping[:properties].update(
       author:     { type: :object },
       commenters: { type: :nested },
-      meta:       { type: "object" }
+      meta:       { type: "object" },
+      details: {
+        properties: {
+          genre: { type: :text }
+        }
+      }
     )
 
     def author
@@ -52,6 +59,17 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
     def meta
       { some: "value" }
     end
+  end
+
+  def test_as_search_document_with_explicit_mapped_objects
+    doc = SpecialFieldsModel.new(
+      details: {
+        genre: 'action',
+        rating: 4.85
+      }
+    ).as_search_document
+
+    assert_equal({ genre: 'action' }, doc[:details])
   end
 
   def test_as_search_document_with_special_fields


### PR DESCRIPTION
**Problem**

ElasticRecord::AsDocument#as_search_document does not respect explicitly-defined object mappings when building documents to serialize.  As a result, too many fields are indexed, and get dynamic mappings.

If no explicit mapping is present (`properties:`), continue to map and render the object dynamically.

Notes:  `type:` is now optional on object types since it is the default value ([source](https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html#CO217-3))