### PR TITLE
Nested mappings define as_search_document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ env:
 
 services:
 - postgresql
+
+addons:
+  postgresql: 9.6

--- a/test/dummy/app/models/widget.rb
+++ b/test/dummy/app/models/widget.rb
@@ -5,6 +5,11 @@ class Widget < ActiveRecord::Base
   belongs_to :warehouse
   validates :color, format: {with: /[a-z]/}
 
+  class WidgetPart
+    include ElasticRecord::Model
+    attr_accessor :name
+  end
+
   self.doctype.mapping[:properties].update(
     'name' => {
       type: 'text',
@@ -20,6 +25,12 @@ class Widget < ActiveRecord::Base
     },
     'price' => {
       type: 'long'
+    },
+    'widget_part' => {
+      type: 'object',
+      properties: {
+        'name' => { type: 'keyword' }
+      }
     }
   )
 

--- a/test/dummy/db/migrate/20180215140125_create_widgets.rb
+++ b/test/dummy/db/migrate/20180215140125_create_widgets.rb
@@ -5,6 +5,7 @@ class CreateWidgets < ActiveRecord::Migration[5.1]
       t.string :name
       t.string :color
       t.integer :price
+      t.jsonb :widget_part
     end
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 20180215140125) do
     t.string "name"
     t.string "color"
     t.integer "price"
+    t.jsonb "widget_part"
   end
 
 end

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -16,9 +16,10 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
 
     Widget.elastic_index.update_document widget.id, name: 'wilbur'
 
-    widget.update! color: 'grey'
+    widget.update! color: 'grey', widget_part: { name: 'Doohicky' }
 
     assert_equal 1, Widget.elastic_search.filter(color: 'grey').count
+    assert_equal 1, Widget.elastic_search.filter('widget_part.name' => 'Doohicky').count
     assert_equal 0, Widget.elastic_search.filter(name: 'elmo').count
   end
 

--- a/test/elastic_record/index/mapping_test.rb
+++ b/test/elastic_record/index/mapping_test.rb
@@ -15,7 +15,12 @@ class ElasticRecord::Index::MappingTest < MiniTest::Test
           "price" => {
             "type" => "long"
           },
-          "warehouse_id" => { "type" => "keyword" }
+          "warehouse_id" => { "type" => "keyword" },
+          "widget_part" => {
+            "properties" => {
+              "name" => { "type" => "keyword" }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Before:
Nested children used a method to define `as_search_document`. In our implementation, that returned everything that was indexed. Fine for most things, except the new range type.

Now:
Nested child objects don't need to implement `as_search_document`. This will automatically traverse the mappings and do the same thing as the parent document.

Any methods that override `as_search_document` need to be updated to take an argument, even if they choose to ignore it.