### PR TITLE
Allow settings to update to be passed in

### DIFF
--- a/lib/elastic_record/index/settings.rb
+++ b/lib/elastic_record/index/settings.rb
@@ -18,8 +18,9 @@ module ElasticRecord
           end
       end
 
-      def update_settings(index_name = alias_name)
-        connection.json_put "/#{index_name}/_settings", settings
+      def update_settings(index_name = alias_name, settings: nil)
+        self.settings = settings if settings
+        connection.json_put "/#{index_name}/_settings", settings || self.settings
       end
 
       def analysis_body


### PR DESCRIPTION
*Problem*
`update_settings` sends the output of the `settings` method which contains things that cannot be updated after index creation.

*Solution*
Allow the settings to be passed in. Also sets them using `settings=` so that the internal representation stays correct.