### PR TITLE
Support multi-document percolation

### DIFF
--- a/lib/elastic_record/percolator_model.rb
+++ b/lib/elastic_record/percolator_model.rb
@@ -28,12 +28,7 @@ module ElasticRecord
       end
 
       def percolate(document)
-        query = {
-          "percolate" => {
-            "field"         => "query",
-            "document"      => document
-          }
-        }
+        query = Arelastic::Queries::Percolate.new("query", document)
 
         elastic_search.filter(query).limit(5000)
       end

--- a/lib/elastic_record/relation/hits.rb
+++ b/lib/elastic_record/relation/hits.rb
@@ -17,12 +17,17 @@ module ElasticRecord
         hits.map { |hit| hit['_id'] }
       end
 
+      def matching_documents_by_id
+        search_hits.each_with_object({}) do |hit, result|
+          result[hit['_id']] = hit['fields']['_percolator_document_slot']
+        end
+      end
+
       private
 
         def search_hits
           search_results['hits']['hits']
         end
-
 
         def search_results
           @search_results ||= begin

--- a/test/elastic_record/relation/hits_test.rb
+++ b/test/elastic_record/relation/hits_test.rb
@@ -34,4 +34,20 @@ class ElasticRecord::Relation::HitsTest < MiniTest::Test
     assert_includes names, 'Latte'
     assert_includes names, 'Americano'
   end
+
+  def test_matching_documents_by_id
+    red_query = WidgetQuery.create(color: 'red')
+    blue_query = WidgetQuery.create(color: 'blue')
+    expected = {
+      red_query.id => [0],
+      blue_query.id => [1]
+    }
+    matching_documents_by_id = WidgetQuery.percolate([
+      { color: 'red' },
+      { color: 'blue' },
+      { color: 'green' }
+    ]).matching_documents_by_id
+
+    assert_equal expected, matching_documents_by_id
+  end
 end


### PR DESCRIPTION
**Problem**

ElasticSearch supports percolating multiple documents at once.  It also supports identifying which documents match which queries.

**Solution**

Support multi-document percolation.  Support returning which documents matched the ids of which queries.

Depends on https://github.com/matthuhiggins/arelastic/pull/19