### PR TITLE
Expose methods for getting the raw results of a query

### DIFF
--- a/lib/elastic_record/relation/hits.rb
+++ b/lib/elastic_record/relation/hits.rb
@@ -17,22 +17,18 @@ module ElasticRecord
         hits.map { |hit| hit['_id'] }
       end
 
-      private
+      def search_hits
+        search_results['hits']['hits']
+      end
 
-        def search_hits
-          search_results['hits']['hits']
+      def search_results
+        @search_results ||= begin
+          options = {typed_keys: true}
+          options[:search_type] = search_type_value if search_type_value
+
+          klass.elastic_index.search(as_elastic, options)
         end
-
-
-        def search_results
-          @search_results ||= begin
-            options = {typed_keys: true}
-            options[:search_type] = search_type_value if search_type_value
-
-            klass.elastic_index.search(as_elastic, options)
-          end
-        end
-
+      end
     end
   end
 end

--- a/test/elastic_record/relation/hits_test.rb
+++ b/test/elastic_record/relation/hits_test.rb
@@ -1,10 +1,6 @@
 require 'helper'
 
 class ElasticRecord::Relation::HitsTest < MiniTest::Test
-  def test_to_hits
-    # assert Widget.elastic_relation.search_results.is_a?(ElasticSearch::Api::Hits)
-  end
-
   def test_to_ids
     red_widget = Widget.create(color: 'red')
     blue_widget = Widget.create(color: 'red')
@@ -33,5 +29,21 @@ class ElasticRecord::Relation::HitsTest < MiniTest::Test
     names = array.map(&:name)
     assert_includes names, 'Latte'
     assert_includes names, 'Americano'
+  end
+
+  def test_search_hits
+    coffees = [Project.new(name: 'Latte'), Project.new(name: 'Americano')]
+    Project.elastic_index.bulk_add(coffees)
+
+    array = Project.elastic_relation.search_hits
+    assert_equal %w(Latte Americano).to_set, array.map { |hit| hit["_source"]["name"] }.to_set
+  end
+
+  def test_search_results
+    coffees = [Project.new(name: 'Latte'), Project.new(name: 'Americano')]
+    Project.elastic_index.bulk_add(coffees)
+
+    results = Project.elastic_relation.search_results
+    %w(took timed_out _shards hits).each { |key| assert results.key?(key) }
   end
 end


### PR DESCRIPTION
For some upcoming features, I would like to access the raw ES results.

It will help with:
1) Finding search scores
2) Getting the name of the query that matched