### PR TITLE
Fixes for find(ids)

### DIFF
--- a/lib/elastic_record/relation/finder_methods.rb
+++ b/lib/elastic_record/relation/finder_methods.rb
@@ -2,12 +2,14 @@ module ElasticRecord
   class Relation
     module FinderMethods
       def find(*ids)
-        ids = ids.flatten
+        return [] if ids.first.is_a?(Array) && ids.first.empty?
+        ids       = ids.flatten
+        id_filter = filter(arelastic.filter.ids(ids)).limit(ids.size)
+
         case ids.size
         when 0; raise ActiveRecord::RecordNotFound.new('empty argument')
-        when 1; filter(arelastic.filter.ids(ids)).first!
-        else
-          filter(arelastic.filter.ids(ids))
+        when 1; id_filter.first!
+        else id_filter
         end
       end
 

--- a/lib/elastic_record/relation/finder_methods.rb
+++ b/lib/elastic_record/relation/finder_methods.rb
@@ -4,7 +4,8 @@ module ElasticRecord
       def find(*ids)
         return [] if ids.first.is_a?(Array) && ids.first.empty?
         ids       = ids.flatten
-        id_filter = filter(arelastic.filter.ids(ids)).limit(ids.size)
+        id_filter = filter(arelastic.filter.ids(ids))
+        id_filter = id_filter.limit(ids.size) unless limit_value
 
         case ids.size
         when 0; raise ActiveRecord::RecordNotFound.new('empty argument')

--- a/test/elastic_record/relation/finder_methods_test.rb
+++ b/test/elastic_record/relation/finder_methods_test.rb
@@ -16,6 +16,11 @@ class ElasticRecord::Relation::FinderMethodsTest < MiniTest::Test
     end
   end
 
+  def test_find_exceed_default_limit
+    widgets = ('a'..'l').map {|color| Widget.create(color: color) }
+    assert_equal 12, Widget.elastic_relation.find(widgets.map(&:id)).size
+  end
+
   def test_find_passed_an_array
     assert_equal 2, Widget.elastic_relation.find([@red_widget.id, @blue_widget.id]).size
     assert_equal 2, Widget.elastic_relation.filter('color' => ['red', 'blue']).find([@red_widget.id, @blue_widget.id]).size
@@ -23,6 +28,7 @@ class ElasticRecord::Relation::FinderMethodsTest < MiniTest::Test
   end
 
   def test_find_passed_an_empty_args
+    assert_equal [], Widget.elastic_relation.find([])
     assert_raises ActiveRecord::RecordNotFound do
       Widget.elastic_relation.find
     end

--- a/test/elastic_record/relation/finder_methods_test.rb
+++ b/test/elastic_record/relation/finder_methods_test.rb
@@ -19,6 +19,7 @@ class ElasticRecord::Relation::FinderMethodsTest < MiniTest::Test
   def test_find_exceed_default_limit
     widgets = ('a'..'l').map {|color| Widget.create(color: color) }
     assert_equal 12, Widget.elastic_relation.find(widgets.map(&:id)).size
+    assert_equal 11, Widget.elastic_relation.limit(11).find(widgets.map(&:id)).size
   end
 
   def test_find_passed_an_array


### PR DESCRIPTION
1) Don't raise an error on Model.find([]) - ActiveRecord doesn't.
2) Override the default ES limit of 10 records when finding by IDs.
