### PR TITLE
Make it easier to store a model entirely in ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ end
 
 ```
 
-Use `elastic_index.load_from_source = true` to configure an index without ActiveRecord.
+Call `load_from_source!` to configure an index without ActiveRecord. Finder methods will be
+delegated to the ElasticRecord module.
 
 ```ruby
 class Product
   include ActiveModel::Model
   include ElasticRecord::Record
-
-  self.elastic_index.load_from_source = true
+  elastic_index.load_from_source!
 end
 ```
 

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -42,7 +42,7 @@ module ElasticRecord
     def initialize(model)
       @model = model
       @disabled = false
-      @load_from_source = false
+      self.load_from_source = false
     end
 
     def initialize_copy(other)
@@ -66,15 +66,15 @@ module ElasticRecord
     end
 
     def load_from_source!
-      @load_from_source = true
+      self.load_from_source = true
       model.singleton_class.delegate :find, :find_by, :find_each, :find_in_batches, :first, to: :elastic_search
     end
 
     def loading_from_source(&block)
-      @load_from_source = true
+      self.load_from_source = true
       yield
     ensure
-      @load_from_source = false
+      self.load_from_source = false
     end
 
     def real_connection

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -65,6 +65,11 @@ module ElasticRecord
       @disabled = false
     end
 
+    def load_from_source!
+      @load_from_source = true
+      model.singleton_class.delegate :find, :find_by, :find_each, :find_in_batches, :first, to: :elastic_search
+    end
+
     def loading_from_source(&block)
       @load_from_source = true
       yield

--- a/lib/elastic_record/model.rb
+++ b/lib/elastic_record/model.rb
@@ -9,6 +9,8 @@ module ElasticRecord
 
         class_attribute :elastic_connection
         self.elastic_connection = ElasticRecord::Connection.new(ElasticRecord::Config.servers, ElasticRecord::Config.connection_options)
+
+        singleton_class.delegate :query, :filter, :aggregate, to: :elastic_search
       end
     end
 

--- a/lib/elastic_record/searching.rb
+++ b/lib/elastic_record/searching.rb
@@ -11,6 +11,7 @@ module ElasticRecord
         elastic_relation
       end
     end
+    alias es elastic_search
 
     def elastic_scope(name, body, &block)
       extension = Module.new(&block) if block

--- a/test/dummy/app/models/project.rb
+++ b/test/dummy/app/models/project.rb
@@ -7,11 +7,10 @@ class Project
 
   include ActiveModel::Model
   include ElasticRecord::Model
+  elastic_index.load_from_source!
 
   attr_accessor :id, :name
   alias_method :as_json, :as_search_document
-
-  elastic_index.load_from_source = true
 
   def as_search_document
     { name: name }

--- a/test/elastic_record/index_test.rb
+++ b/test/elastic_record/index_test.rb
@@ -31,6 +31,15 @@ class ElasticRecord::IndexTest < MiniTest::Test
     refute index.load_from_source
   end
 
+  def test_delegations_when_loading_from_source
+    project = Project.new(name: 'Something')
+    Project.elastic_index.index_record(project)
+
+    found_project = Project.first
+    assert_equal 'Something', found_project.name
+    assert_equal 'Something', Project.find(found_project.id).name
+  end
+
   private
 
     def index

--- a/test/elastic_record/searching_test.rb
+++ b/test/elastic_record/searching_test.rb
@@ -9,7 +9,9 @@ class ElasticRecord::SearchingTest < MiniTest::Test
   end
 
   def test_elastic_search
-
+    widget = Widget.create(color: 'red')
+    assert_equal widget, Widget.elastic_search.filter(color: 'red').first
+    assert_equal widget, Widget.es.filter(color: 'red').first
   end
 
   def test_elastic_scope


### PR DESCRIPTION
Simply `include ElasticRecord::LoadFromSource` in the model.

No need for models to set the flag manually. Enables `Model.first`,
`find` and friends for easy lookup.