### PR TITLE
setting_overrides should override defaults

### DIFF
--- a/lib/elastic_record/index/manage.rb
+++ b/lib/elastic_record/index/manage.rb
@@ -12,7 +12,7 @@ module ElasticRecord
           "mappings" => {
             mapping_type => mapping
           },
-          "settings" => setting_overrides.merge(settings)
+          "settings" => settings.merge(setting_overrides)
         }
         index_name
       end

--- a/test/elastic_record/index/manage_test.rb
+++ b/test/elastic_record/index/manage_test.rb
@@ -23,7 +23,7 @@ class ElasticRecord::Index::ManageTest < MiniTest::Test
     ElasticRecord::Config.default_index_settings = {
       number_of_replicas: '2'
     }
-    index.remove_instance_variable('@settings')
+    index.remove_instance_variable('@settings') if index.instance_variable_defined?('@settings')
     index.create 'felons_default'
     assert_equal '2', index_settings('felons_default')['index']['number_of_replicas']
     index.create 'felons_override', setting_overrides: { number_of_replicas: 4 }


### PR DESCRIPTION
The previous code had the opposite behavior. The bug strangely manifested itself only when `ElasticRecord::Config.default_index_settings` was set.

Also, add a test for `setting_overrides`.