### PR TITLE
Change Arelastic.query to Arelastic.queries

### DIFF
--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test}/*`.split("\n")
 
-  s.add_dependency 'arelastic', '>= 2.5.0'
+  s.add_dependency 'arelastic', '>= 2.6.0'
   s.add_dependency 'activemodel'
 end

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -197,11 +197,11 @@ module ElasticRecord
           filter = build_filter(filters)
 
           query_and_filter = if filter
-            arelastic.query.bool(filter: filter, must: query)
+            arelastic.queries.bool(filter: filter, must: query)
           elsif query
             query
           else
-            arelastic.query.match_all
+            arelastic.queries.match_all
           end
 
           Arelastic::Searches::Query.new query_and_filter


### PR DESCRIPTION
Updated to change reference from `arelastic.query` to `arelastic.queries`.