### PR TITLE
Index suffix

### DIFF
--- a/lib/elastic_record/config.rb
+++ b/lib/elastic_record/config.rb
@@ -2,17 +2,11 @@ require 'active_support/core_ext/class/attribute'
 
 module ElasticRecord
   class Config
-    class_attribute :connection_options
-    self.connection_options = {}
-
-    class_attribute :default_index_settings
-    self.default_index_settings = {}
-
-    class_attribute :model_names
-    self.model_names = []
-
-    class_attribute :scroll_keep_alive
-    self.scroll_keep_alive = '5m'
+    class_attribute :connection_options,     default: {}
+    class_attribute :default_index_settings, default: {}
+    class_attribute :model_names,            default: []
+    class_attribute :scroll_keep_alive,      default: '5m'
+    class_attribute :index_suffix
 
     class << self
       def models
@@ -32,6 +26,7 @@ module ElasticRecord
 
       def settings=(settings)
         self.servers = settings['servers']
+        self.index_suffix = settings['index_suffix']
         self.connection_options = settings
 
         if settings['scroll_keep_alive'].present?

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -50,11 +50,11 @@ module ElasticRecord
     end
 
     def alias_name=(name)
-      @alias_name = name
+      @alias_name = add_suffix(name)
     end
 
     def alias_name
-      @alias_name ||= model.base_class.name.demodulize.underscore.pluralize
+      @alias_name ||= add_suffix(model.base_class.name.demodulize.underscore.pluralize)
     end
 
     def disable!
@@ -95,6 +95,15 @@ module ElasticRecord
     end
 
     private
+
+      def add_suffix(name)
+        suffix = ElasticRecord::Config.index_suffix
+        if suffix && !name.end_with?(suffix)
+          name + "_#{suffix}"
+        else
+          name
+        end
+      end
 
       def new_index_name
         "#{alias_name}_#{Time.now.utc.strftime('%Y%m%d_%H%M%S')}"

--- a/test/elastic_record/index_test.rb
+++ b/test/elastic_record/index_test.rb
@@ -8,7 +8,9 @@ class ElasticRecord::IndexTest < MiniTest::Test
   end
 
   def test_alias_name
-    assert_equal 'widgets', index.alias_name
+    with_test_suffix do
+      assert_equal 'widgets_test', index.alias_name
+    end
   end
 
   def test_disable
@@ -44,5 +46,12 @@ class ElasticRecord::IndexTest < MiniTest::Test
 
     def index
       @index ||= ElasticRecord::Index.new(Widget)
+    end
+
+    def with_test_suffix
+      ElasticRecord::Config.index_suffix = 'test'
+      yield
+    ensure
+      ElasticRecord::Config.index_suffix = nil
     end
 end

--- a/test/elastic_record/index_test.rb
+++ b/test/elastic_record/index_test.rb
@@ -8,8 +8,11 @@ class ElasticRecord::IndexTest < MiniTest::Test
   end
 
   def test_alias_name
+    assert_equal 'widgets', index.alias_name
+
     ElasticRecord::Config.index_suffix = 'test'
-    assert_equal 'widgets_test', index.alias_name
+    index.alias_name = "other_name"
+    assert_equal 'other_name_test', index.alias_name
   ensure
     ElasticRecord::Config.index_suffix = nil
   end

--- a/test/elastic_record/index_test.rb
+++ b/test/elastic_record/index_test.rb
@@ -8,9 +8,10 @@ class ElasticRecord::IndexTest < MiniTest::Test
   end
 
   def test_alias_name
-    with_test_suffix do
-      assert_equal 'widgets_test', index.alias_name
-    end
+    ElasticRecord::Config.index_suffix = 'test'
+    assert_equal 'widgets_test', index.alias_name
+  ensure
+    ElasticRecord::Config.index_suffix = nil
   end
 
   def test_disable
@@ -46,12 +47,5 @@ class ElasticRecord::IndexTest < MiniTest::Test
 
     def index
       @index ||= ElasticRecord::Index.new(Widget)
-    end
-
-    def with_test_suffix
-      ElasticRecord::Config.index_suffix = 'test'
-      yield
-    ensure
-      ElasticRecord::Config.index_suffix = nil
     end
 end


### PR DESCRIPTION
It can be used to append "test" to the indexes and aliases so that one
ElasticSearch server can be used for tests and development.