### PR TITLE
Add find_hits_in_batches

### DIFF
--- a/lib/elastic_record/relation/batches.rb
+++ b/lib/elastic_record/relation/batches.rb
@@ -8,14 +8,20 @@ module ElasticRecord
       end
 
       def find_in_batches(options = {})
-        build_scroll_enumerator(options).each_slice do |hits|
-          yield SearchHits.new(klass, hits).to_records
+        find_hits_in_batches(options) do |hits|
+          yield hits.to_records
         end
       end
 
       def find_ids_in_batches(options = {})
+        find_hits_in_batches(options) do |hits|
+          yield hits.to_ids
+        end
+      end
+
+      def find_hits_in_batches(options = {})
         build_scroll_enumerator(options).each_slice do |hits|
-          yield SearchHits.new(klass, hits).to_ids
+          yield SearchHits.new(klass, hits)
         end
       end
 

--- a/test/elastic_record/relation/batches_test.rb
+++ b/test/elastic_record/relation/batches_test.rb
@@ -21,8 +21,7 @@ class ElasticRecord::Relation::BatchesTest < MiniTest::Test
     Widget.elastic_relation.find_hits_in_batches do |hits|
       results << hits
     end
-    expected_ids = [[@red_widget, @blue_widget, @green_widget].to_set]
-    assert_equal expected_ids, results.map(&:to_records).map(&:to_set)
+    assert_equal [@red_widget, @blue_widget, @green_widget].to_set, results.flatten.to_set
   end
 
   def test_find_ids_in_batches

--- a/test/elastic_record/relation/batches_test.rb
+++ b/test/elastic_record/relation/batches_test.rb
@@ -21,7 +21,7 @@ class ElasticRecord::Relation::BatchesTest < MiniTest::Test
     Widget.elastic_relation.find_hits_in_batches do |hits|
       results << hits
     end
-    assert_equal [@red_widget, @blue_widget, @green_widget].to_set, results.flatten.to_set
+    assert_equal [[@red_widget, @blue_widget, @green_widget].to_set], results.map(&:to_records).map(&:to_set)
   end
 
   def test_find_ids_in_batches

--- a/test/elastic_record/relation/batches_test.rb
+++ b/test/elastic_record/relation/batches_test.rb
@@ -16,6 +16,15 @@ class ElasticRecord::Relation::BatchesTest < MiniTest::Test
   #   assert_equal [@red_widget, @blue_widget, @green_widget].to_set, results.to_set
   # end
 
+  def test_find_hits_in_batches
+    results = []
+    Widget.elastic_relation.find_hits_in_batches do |hits|
+      results << hits
+    end
+    expected_ids = [[@red_widget.id.to_s, @blue_widget.id.to_s, @green_widget.id.to_s].to_set]
+    assert_equal expected_ids, results.map(&:to_ids).map(&:to_set)
+  end
+
   def test_find_ids_in_batches
     results = []
     Widget.elastic_relation.find_ids_in_batches do |ids|

--- a/test/elastic_record/relation/batches_test.rb
+++ b/test/elastic_record/relation/batches_test.rb
@@ -21,8 +21,8 @@ class ElasticRecord::Relation::BatchesTest < MiniTest::Test
     Widget.elastic_relation.find_hits_in_batches do |hits|
       results << hits
     end
-    expected_ids = [[@red_widget.id.to_s, @blue_widget.id.to_s, @green_widget.id.to_s].to_set]
-    assert_equal expected_ids, results.map(&:to_ids).map(&:to_set)
+    expected_ids = [[@red_widget, @blue_widget, @green_widget].to_set]
+    assert_equal expected_ids, results.map(&:to_records).map(&:to_set)
   end
 
   def test_find_ids_in_batches


### PR DESCRIPTION
Adds a convenience method that yields `SearchHits` when scrolling.