### PR TITLE
Clear scroll after #each_slice

### DIFF
--- a/lib/elastic_record/config.rb
+++ b/lib/elastic_record/config.rb
@@ -5,7 +5,7 @@ module ElasticRecord
     class_attribute :connection_options,     default: {}
     class_attribute :default_index_settings, default: {}
     class_attribute :model_names,            default: []
-    class_attribute :scroll_keep_alive,      default: '5m'
+    class_attribute :scroll_keep_alive,      default: '2m'
     class_attribute :index_suffix
 
     class << self

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -7,7 +7,7 @@ module ElasticRecord
       def initialize(elastic_index, search: nil, scroll_id: nil, keep_alive:, batch_size:)
         @elastic_index = elastic_index
         @search        = search
-        @scroll_ids    = []
+        @scroll_ids    = [scroll_id].compact
         @keep_alive    = keep_alive
         @batch_size    = batch_size
 
@@ -30,7 +30,7 @@ module ElasticRecord
       end
 
       def request_next_scroll
-        response = scroll_id.any? ? @elastic_index.scroll(scroll_ids.last, keep_alive) : initial_search_response
+        response = scroll_ids.any? ? @elastic_index.scroll(scroll_ids.last, keep_alive) : initial_search_response
         @scroll_ids << response['_scroll_id']
         response
       end

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -16,6 +16,8 @@ module ElasticRecord
         while (hits = request_more_hits.hits).any?
           hits.each_slice(batch_size, &block)
         end
+
+        @elastic_index.delete_scroll(scroll_id)
       end
 
       def request_more_ids

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -29,14 +29,17 @@ module ElasticRecord
       end
 
       def request_next_scroll
-        response = scroll_id.present? ? @elastic_index.scroll(scroll_id, keep_alive) : initial_search_response
-        new_scroll_id = response['_scroll_id']
+        if scroll_id
+          response = @elastic_index.scroll(scroll_id, keep_alive)
 
-        if scroll_id && new_scroll_id != scroll_id
-          @elastic_index.delete_scroll(scroll_id)
+          if response['_scroll_id'] != scroll_id
+            @elastic_index.delete_scroll(scroll_id)
+          end
+        else
+          response = initial_search_response
         end
 
-        @scroll_id = new_scroll_id
+        @scroll_id =  response['_scroll_id']
 
         response
       end

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -174,7 +174,7 @@ module ElasticRecord
       end
 
       def clear_scroll(scroll_ids)
-        connection.json_delete('/_search/scroll', { scroll_id: scroll_ids) })
+        connection.json_delete('/_search/scroll', { scroll_id: scroll_ids })
       end
 
       def bulk(options = {}, &block)

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -3,7 +3,7 @@ require 'active_support/core_ext/object/to_query'
 module ElasticRecord
   class Index
     class ScrollEnumerator
-      attr_reader :scroll_id, :keep_alive, :batch_size, :scroll_ids
+      attr_reader :keep_alive, :batch_size, :scroll_ids
       def initialize(elastic_index, search: nil, scroll_id: nil, keep_alive:, batch_size:)
         @elastic_index = elastic_index
         @search        = search
@@ -170,7 +170,7 @@ module ElasticRecord
       end
 
       def clear_scroll(scroll_ids)
-        connection.json_delete('/_search/scroll', { scroll_id: [scroll_ids] })
+        connection.json_delete('/_search/scroll', { scroll_id: Array.wrap(scroll_ids) })
       end
 
       def bulk(options = {}, &block)

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -31,7 +31,11 @@ module ElasticRecord
 
       def request_next_scroll
         response = scroll_ids.any? ? @elastic_index.scroll(scroll_ids.last, keep_alive) : initial_search_response
-        @scroll_ids << response['_scroll_id']
+
+        if new_scroll_id = response['_scroll_id']
+          @scroll_ids << new_scroll_id
+        end
+
         response
       end
 
@@ -170,7 +174,7 @@ module ElasticRecord
       end
 
       def clear_scroll(scroll_ids)
-        connection.json_delete('/_search/scroll', { scroll_id: Array.wrap(scroll_ids) })
+        connection.json_delete('/_search/scroll', { scroll_id: scroll_ids) })
       end
 
       def bulk(options = {}, &block)

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -10,7 +10,6 @@ module ElasticRecord
         @scroll_id     = scroll_id
         @keep_alive    = keep_alive
         @batch_size    = batch_size
-
       end
 
       def each_slice(&block)

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -174,8 +174,8 @@ module ElasticRecord
         end
       end
 
-      def delete_scroll(scroll_ids)
-        connection.json_delete('/_search/scroll', { scroll_id: scroll_ids })
+      def delete_scroll(scroll_id)
+        connection.json_delete('/_search/scroll', { scroll_id: scroll_id })
       end
 
       def bulk(options = {}, &block)

--- a/test/elastic_record/config_test.rb
+++ b/test/elastic_record/config_test.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 class ElasticRecord::ConfigTest < MiniTest::Test
   def test_defaults
-    assert_equal '5m', ElasticRecord::Config.scroll_keep_alive
+    assert_equal '2m', ElasticRecord::Config.scroll_keep_alive
   end
 
   def test_models

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -106,21 +106,14 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
   end
 
   def test_each_slice_clear
-    index.index_document('bob', name: 'bob')
-    index.index_document('bobs', name: 'bob')
-
-    scroll_enumerator = index.build_scroll_enumerator(
-      search: { 'query' => { query_string: { query: 'name:bob' } } },
-      batch_size: 1,
-      keep_alive: '1ms'
-    )
+    scroll_enumerator = index.build_scroll_enumerator(search: {'query' => {query_string: {query: ''}}})
 
     scroll_enumerator.each_slice
-    assert scroll_enumerator.scroll_ids.any?
-    assert_equal 1, index.connection.deferred_actions.size
     delete = index.connection.deferred_actions.first
+
+    assert scroll_enumerator.scroll_ids.any?
     assert_equal :json_delete, delete.method
-    assert_equal scroll_enumerator.scroll_ids, delete.args.second[:scroll_id]
+    assert_equal ['/_search/scroll', {scroll_id: scroll_enumerator.scroll_ids}], delete.args
   end
 
   def test_invalid_scroll_error

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -114,23 +114,20 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     scroll_enumerator.each_slice do |slice|
       batches << slice
     end
-    # delete = index.connection.deferred_actions.first
 
     assert_equal 10, batches.size
-    # refute scroll_enumerator.scroll_ids.any?
-    # assert_equal :json_delete, delete.method
   end
 
-  # def reset_scroll
-  #   scroll_id = 'test'
-  #   scroll_enumerator = index.build_scroll_enumerator(search: {'query' => {query_string: {query: ''}}}, scroll_id: scroll_id)
-  #   scroll_enumerator.reset_scroll
+  def test_delete_scroll
+    scroll_enumerator = index.build_scroll_enumerator(search: {'query' => {query_string: {query: ''}}})
+    scroll_enumerator.initial_search_response
 
-  #   refute scroll_enumerator.scroll_ids.any?
-  #   refute scroll_enumerator.instance_eval('@initial_search_response')
-  #   assert_equal :json_delete, delete.method
-  #   assert_equal ['/_search/scroll', {scroll_id: scroll_id}], delete.args
-  # end
+    index.delete_scroll(scroll_enumerator.scroll_id)
+    delete = index.connection.deferred_actions.first
+
+    assert_equal :json_delete, delete.method
+    assert_equal ['/_search/scroll', {scroll_id: scroll_enumerator.scroll_id}], delete.args
+  end
 
   def test_invalid_scroll_error
     assert_raises ElasticRecord::InvalidScrollError do

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -99,10 +99,28 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     )
 
     scroll_enumerator.request_more_hits
-    index.connection.json_delete '/_search/scroll', scroll_id: scroll_enumerator.scroll_id
+    scroll_enumerator.clear
     assert_raises ElasticRecord::ExpiredScrollError do
       scroll_enumerator.request_more_hits
     end
+  end
+
+  def test_each_slice_clear
+    index.index_document('bob', name: 'bob')
+    index.index_document('bobs', name: 'bob')
+
+    scroll_enumerator = index.build_scroll_enumerator(
+      search: { 'query' => { query_string: { query: 'name:bob' } } },
+      batch_size: 1,
+      keep_alive: '1ms'
+    )
+
+    scroll_enumerator.each_slice
+    assert scroll_enumerator.scroll_ids.any?
+    assert_equal 1, index.connection.deferred_actions.size
+    delete = index.connection.deferred_actions.first
+    assert_equal :json_delete, delete.method
+    assert_equal scroll_enumerator.scroll_ids, delete.args.second[:scroll_id]
   end
 
   def test_invalid_scroll_error

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -116,17 +116,11 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     end
 
     assert_equal 10, batches.size
-  end
 
-  def test_delete_scroll
-    scroll_enumerator = index.build_scroll_enumerator(search: {'query' => {query_string: {query: ''}}})
-    scroll_enumerator.initial_search_response
-
-    index.delete_scroll(scroll_enumerator.scroll_id)
-    delete = index.connection.deferred_actions.first
-
-    assert_equal :json_delete, delete.method
-    assert_equal ['/_search/scroll', {scroll_id: scroll_enumerator.scroll_id}], delete.args
+    # Assert context was removed
+    assert_raises ElasticRecord::ExpiredScrollError do
+      scroll_enumerator.request_more_hits
+    end
   end
 
   def test_invalid_scroll_error


### PR DESCRIPTION
After a batch operation (which largely use #each_slice) we should clear
the scroll by default to reduce the cost of these operations.

This implementation clears them all in 1 DELETE after yielding search results. You could probably delete as you go as well. More requests, but also cleans up sooner. I think this works, but I could see the argument for implementing that as well. Open for discussion.