### PR TITLE
Ensure provided nested object fields submit

### DIFF
--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -4,7 +4,7 @@ module ElasticRecord
       mapping_properties.each_with_object({}) do |(field, mapping), result|
         value = value_for_elastic_search field, mapping, mapping_properties
 
-        unless value.nil?
+        if !value.nil? || provided?(field)
           result[field] = value
         end
       end

--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -4,7 +4,7 @@ module ElasticRecord
       mapping_properties.each_with_object({}) do |(field, mapping), result|
         value = value_for_elastic_search field, mapping, mapping_properties
 
-        if !value.nil? || provided?(field)
+        if !value.nil? || (respond_to?(:provided?) && provided?(field))
           result[field] = value
         end
       end

--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -21,7 +21,7 @@ module ElasticRecord
     end
 
     def value_for_elastic_search(field, mapping, mapping_properties, is_update = false)
-      return unless (value = try(field))
+      return if (value = try(field)).nil?
 
       case mapping[:type]&.to_sym
       when :object

--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -4,48 +4,42 @@ module ElasticRecord
       mapping_properties.each_with_object({}) do |(field, mapping), result|
         value = value_for_elastic_search field, mapping, mapping_properties
 
-        if !value.nil? || (respond_to?(:provided?) && provided?(field))
+        unless value.nil?
           result[field] = value
         end
       end
     end
 
-    def as_partial_update_document
-      mapping_properties = elastic_index.mapping[:properties]
+    def as_partial_update_document(mapping_properties = elastic_index.mapping[:properties])
       changed_fields = respond_to?(:saved_changes) ? saved_changes.keys : changed
 
       changed_fields.each_with_object({}) do |field, result|
         if field_mapping = mapping_properties[field]
-          result[field] = value_for_elastic_search field, field_mapping, mapping_properties
+          result[field] = value_for_elastic_search field, field_mapping, mapping_properties, true
         end
       end
     end
 
-    def value_for_elastic_search(field, mapping, mapping_properties)
-      value = try field
-      return if value.nil?
+    def value_for_elastic_search(field, mapping, mapping_properties, is_update = false)
+      return unless (value = try(field))
 
-      value =
-        case mapping[:type]&.to_sym
-        when :object
-          object_mapping_properties = mapping_properties.dig(field, :properties)
-          value_for_elastic_search_object(value, object_mapping_properties)
-        when :nested
-          object_mapping_properties = mapping_properties.dig(field, :properties)
-          value.map { |entry| value_for_elastic_search_object(entry, object_mapping_properties) }
-        when :integer_range, :float_range, :long_range, :double_range, :date_range
-          value_for_elastic_search_range(value)
-        else
-          value
-        end
-
-      if value.present? || value == false
-        value
+      case mapping[:type]&.to_sym
+      when :object
+        object_mapping_properties = mapping_properties.dig(field, :properties)
+        value_for_elastic_search_object(value, object_mapping_properties, is_update)
+      when :nested
+        object_mapping_properties = mapping_properties.dig(field, :properties)
+        value.map { |entry| value_for_elastic_search_object(entry, object_mapping_properties, is_update) }
+      when :integer_range, :float_range, :long_range, :double_range, :date_range
+        value_for_elastic_search_range(value)
+      else
+        value if value.present? || value == false
       end
     end
 
-    def value_for_elastic_search_object(object, nested_mapping)
-      object.respond_to?(:as_search_document) ? object.as_search_document(nested_mapping) : object
+    def value_for_elastic_search_object(object, nested_mapping, is_update)
+      method = is_update ? :as_partial_update_document : :as_search_document
+      object.respond_to?(method) ? object.public_send(method, nested_mapping) : object
     end
 
     def value_for_elastic_search_range(range)

--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -28,6 +28,8 @@ module ElasticRecord
         object_mapping_properties = mapping_properties.dig(field, :properties)
         value_for_elastic_search_object(value, object_mapping_properties, is_update)
       when :nested
+        return nil if value.empty?
+
         object_mapping_properties = mapping_properties.dig(field, :properties)
         value.map { |entry| value_for_elastic_search_object(entry, object_mapping_properties, is_update) }
       when :integer_range, :float_range, :long_range, :double_range, :date_range

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -21,6 +21,11 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
     assert_equal 1, Widget.elastic_search.filter(color: 'grey').count
     assert_equal 1, Widget.elastic_search.filter('widget_part.name' => 'Doohicky').count
     assert_equal 0, Widget.elastic_search.filter(name: 'elmo').count
+
+    widget.widget_part = { name: nil }
+    widget.save!
+
+    assert_equal 1, Widget.elastic_search.filter('widget_part.name' => nil).count
   end
 
   class SpecialFieldsModel


### PR DESCRIPTION
Currently in elastic record attempts to clear nested fields (set them
to null) are dropped. To allow this, we need to allow specifically
provided (in the active record sense) fields to be submitted.

For example, if you had a nested field/object sub_widget on a widget, and tried to "clear" a field on subwidget by setting the value to nil, that update would be dropped from the update sent to ElasticSearch.

### Example

```ruby
widget = Widget.create(name: 'My Widget', sub_widget: SubWidget.new(sub_field: 'hi!'))
sub_widget = widget.sub_widget

sub_widget.sub_field = nil
widget.sub_widget = sub_widget

widget.save!
```

The resulting post wouldn't include sub_field, and this the old value would persist according to the source document in ElasticSearch.

This change corrects this problem.