### PR TITLE
multi_search support

### DIFF
--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -3,6 +3,7 @@ require 'elastic_record/index/deferred'
 require 'elastic_record/index/documents'
 require 'elastic_record/index/manage'
 require 'elastic_record/index/mapping'
+require 'elastic_record/index/search'
 require 'elastic_record/index/settings'
 require 'elastic_record/index/mapping_type'
 
@@ -27,7 +28,7 @@ module ElasticRecord
   # [update_mapping]
   #   Update elastic search's mapping
   class Index
-    include Documents
+    include Documents, Search
     include Manage
     include Mapping, Settings
     include Analyze

--- a/lib/elastic_record/index/deferred.rb
+++ b/lib/elastic_record/index/deferred.rb
@@ -40,7 +40,7 @@ module ElasticRecord
 
             if READ_METHODS.include?(method)
               flush_deferred_actions!
-              if method == :json_get && args.first =~ /^\/(.*)\/_search/
+              if method == :json_get && args.first =~ /^\/(.*)\/_m?search/
                 index.real_connection.json_post("/#{$1.partition('/').first}/_refresh")
               end
 

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -155,6 +155,16 @@ module ElasticRecord
         get url, elastic_query.update('_source' => load_from_source)
       end
 
+      def multi_search(elastic_queries)
+        url = "_msearch"
+
+        queries = elastic_queries.flat_map do |query|
+          ["{}", query.update('_source' => load_from_source).to_json]
+        end
+        queries = queries.join("\n") + "\n"
+        get url, queries
+      end
+
       def explain(id, elastic_query)
         get "_explain", elastic_query
       end

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -2,62 +2,6 @@ require 'active_support/core_ext/object/to_query'
 
 module ElasticRecord
   class Index
-    class ScrollEnumerator
-      attr_reader :keep_alive, :batch_size, :scroll_id
-      def initialize(elastic_index, search: nil, scroll_id: nil, keep_alive:, batch_size:)
-        @elastic_index = elastic_index
-        @search        = search
-        @scroll_id     = scroll_id
-        @keep_alive    = keep_alive
-        @batch_size    = batch_size
-      end
-
-      def each_slice(&block)
-        while (hits = request_more_hits.hits).any?
-          hits.each_slice(batch_size, &block)
-        end
-
-        @elastic_index.delete_scroll(scroll_id)
-      end
-
-      def request_more_ids
-        request_more_hits.to_ids
-      end
-
-      def request_more_hits
-        SearchHits.from_response(request_next_scroll)
-      end
-
-      def request_next_scroll
-        if scroll_id
-          response = @elastic_index.scroll(scroll_id, keep_alive)
-
-          if response['_scroll_id'] != scroll_id
-            @elastic_index.delete_scroll(scroll_id)
-          end
-        else
-          response = initial_search_response
-        end
-
-        @scroll_id =  response['_scroll_id']
-
-        response
-      end
-
-      def total_hits
-        initial_search_response['hits']['total']
-      end
-
-      def initial_search_response
-        @initial_search_response ||= begin
-          search_options = { size: batch_size, scroll: keep_alive }
-          elastic_query = @search.reverse_merge('sort' => '_doc')
-
-          @elastic_index.search(elastic_query, search_options)
-        end
-      end
-    end
-
     module Documents
       def index_record(record, index_name: alias_name)
         unless disabled
@@ -140,48 +84,6 @@ module ElasticRecord
             hits.each { |hit| delete_document hit['_id'] }
           end
         end
-      end
-
-      def record_exists?(id)
-        get(id)['found']
-      end
-
-      def search(elastic_query, options = {})
-        url = "_search"
-        if options.any?
-          url += "?#{options.to_query}"
-        end
-
-        get url, elastic_query.update('_source' => load_from_source)
-      end
-
-      def multi_search(headers_and_bodies)
-        queries = headers_and_bodies.flat_map { |header, body| [header.to_json, body.to_json] }
-        queries = queries.join("\n") + "\n"
-        get "_msearch", queries
-      end
-
-      def explain(id, elastic_query)
-        get "_explain", elastic_query
-      end
-
-      def build_scroll_enumerator(search: nil, scroll_id: nil, batch_size: 100, keep_alive: ElasticRecord::Config.scroll_keep_alive)
-        ScrollEnumerator.new(self, search: search, scroll_id: scroll_id, batch_size: batch_size, keep_alive: keep_alive)
-      end
-
-      def scroll(scroll_id, scroll_keep_alive)
-        options = {scroll_id: scroll_id, scroll: scroll_keep_alive}
-        connection.json_get("/_search/scroll?#{options.to_query}")
-      rescue ElasticRecord::ConnectionError => e
-        case e.status_code
-        when '400' then raise ElasticRecord::InvalidScrollError, e.message
-        when '404' then raise ElasticRecord::ExpiredScrollError, e.message
-        else raise e
-        end
-      end
-
-      def delete_scroll(scroll_id)
-        connection.json_delete('/_search/scroll', { scroll_id: scroll_id })
       end
 
       def bulk(options = {}, &block)

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -155,14 +155,10 @@ module ElasticRecord
         get url, elastic_query.update('_source' => load_from_source)
       end
 
-      def multi_search(elastic_queries)
-        url = "_msearch"
-
-        queries = elastic_queries.flat_map do |query|
-          ["{}", query.update('_source' => load_from_source).to_json]
-        end
+      def multi_search(headers_and_bodies)
+        queries = headers_and_bodies.flat_map { |header, body| [header.to_json, body.to_json] }
         queries = queries.join("\n") + "\n"
-        get url, queries
+        get "_msearch", queries
       end
 
       def explain(id, elastic_query)

--- a/lib/elastic_record/index/search.rb
+++ b/lib/elastic_record/index/search.rb
@@ -1,0 +1,105 @@
+require 'active_support/core_ext/object/to_query'
+
+module ElasticRecord
+  class Index
+    class ScrollEnumerator
+      attr_reader :keep_alive, :batch_size, :scroll_id
+      def initialize(elastic_index, search: nil, scroll_id: nil, keep_alive:, batch_size:)
+        @elastic_index = elastic_index
+        @search        = search
+        @scroll_id     = scroll_id
+        @keep_alive    = keep_alive
+        @batch_size    = batch_size
+      end
+
+      def each_slice(&block)
+        while (hits = request_more_hits.hits).any?
+          hits.each_slice(batch_size, &block)
+        end
+
+        @elastic_index.delete_scroll(scroll_id)
+      end
+
+      def request_more_ids
+        request_more_hits.to_ids
+      end
+
+      def request_more_hits
+        SearchHits.from_response(request_next_scroll)
+      end
+
+      def request_next_scroll
+        if scroll_id
+          response = @elastic_index.scroll(scroll_id, keep_alive)
+
+          if response['_scroll_id'] != scroll_id
+            @elastic_index.delete_scroll(scroll_id)
+          end
+        else
+          response = initial_search_response
+        end
+
+        @scroll_id =  response['_scroll_id']
+
+        response
+      end
+
+      def total_hits
+        initial_search_response['hits']['total']
+      end
+
+      def initial_search_response
+        @initial_search_response ||= begin
+          search_options = { size: batch_size, scroll: keep_alive }
+          elastic_query = @search.reverse_merge('sort' => '_doc')
+
+          @elastic_index.search(elastic_query, search_options)
+        end
+      end
+    end
+
+    module Search
+      def record_exists?(id)
+        get(id)['found']
+      end
+
+      def search(elastic_query, options = {})
+        url = "_search"
+        if options.any?
+          url += "?#{options.to_query}"
+        end
+
+        get url, elastic_query.update('_source' => load_from_source)
+      end
+
+      def multi_search(headers_and_bodies)
+        queries = headers_and_bodies.flat_map { |header, body| [header.to_json, body.to_json] }
+        queries = queries.join("\n") + "\n"
+        get "_msearch", queries
+      end
+
+      def explain(id, elastic_query)
+        get "_explain", elastic_query
+      end
+
+      def build_scroll_enumerator(search: nil, scroll_id: nil, batch_size: 100, keep_alive: ElasticRecord::Config.scroll_keep_alive)
+        ScrollEnumerator.new(self, search: search, scroll_id: scroll_id, batch_size: batch_size, keep_alive: keep_alive)
+      end
+
+      def scroll(scroll_id, scroll_keep_alive)
+        options = {scroll_id: scroll_id, scroll: scroll_keep_alive}
+        connection.json_get("/_search/scroll?#{options.to_query}")
+      rescue ElasticRecord::ConnectionError => e
+        case e.status_code
+        when '400' then raise ElasticRecord::InvalidScrollError, e.message
+        when '404' then raise ElasticRecord::ExpiredScrollError, e.message
+        else raise e
+        end
+      end
+
+      def delete_scroll(scroll_id)
+        connection.json_delete('/_search/scroll', { scroll_id: scroll_id })
+      end
+    end
+  end
+end

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -78,57 +78,6 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     assert index.record_exists?('joe')
   end
 
-  def test_build_scroll_enumerator
-    index.index_document('bob', name: 'bob')
-    index.index_document('joe', name: 'joe')
-
-    scroll_enumerator = index.build_scroll_enumerator(search: {'query' => {query_string: {query: 'name:bob'}}})
-
-    assert_equal 1, scroll_enumerator.total_hits
-    assert_equal 1, scroll_enumerator.request_more_ids.size
-  end
-
-  def test_expired_scroll_error
-    index.index_document('bob', name: 'bob')
-    index.index_document('bobs', name: 'bob')
-
-    scroll_enumerator = index.build_scroll_enumerator(
-      search: { 'query' => { query_string: { query: 'name:bob' } } },
-      batch_size: 1,
-      keep_alive: '1ms'
-    )
-
-    scroll_enumerator.request_more_hits
-    index.delete_scroll(scroll_enumerator.scroll_id)
-    assert_raises ElasticRecord::ExpiredScrollError do
-      scroll_enumerator.request_more_hits
-    end
-  end
-
-  def test_each_slice
-    10.times { |i| index.index_document("bob#{i}", color: 'red') }
-    batches = []
-
-    scroll_enumerator = index.build_scroll_enumerator(search: {'query' => {query_string: {query: 'color:red'}}}, batch_size: 1)
-
-    scroll_enumerator.each_slice do |slice|
-      batches << slice
-    end
-
-    assert_equal 10, batches.size
-
-    # Assert context was removed
-    assert_raises ElasticRecord::ExpiredScrollError do
-      scroll_enumerator.request_more_hits
-    end
-  end
-
-  def test_invalid_scroll_error
-    assert_raises ElasticRecord::InvalidScrollError do
-      index.scroll('invalid', '1m')
-    end
-  end
-
   def test_bulk
     assert_nil index.current_bulk_batch
 

--- a/test/elastic_record/index/search_test.rb
+++ b/test/elastic_record/index/search_test.rb
@@ -1,0 +1,60 @@
+require "helper"
+
+class ElasticRecord::Index::SearchTest < MiniTest::Test
+  def test_build_scroll_enumerator
+    index.index_document('bob', name: 'bob')
+    index.index_document('joe', name: 'joe')
+
+    scroll_enumerator = index.build_scroll_enumerator(search: {'query' => {query_string: {query: 'name:bob'}}})
+
+    assert_equal 1, scroll_enumerator.total_hits
+    assert_equal 1, scroll_enumerator.request_more_ids.size
+  end
+
+  def test_expired_scroll_error
+    index.index_document('bob', name: 'bob')
+    index.index_document('bobs', name: 'bob')
+
+    scroll_enumerator = index.build_scroll_enumerator(
+      search: { 'query' => { query_string: { query: 'name:bob' } } },
+      batch_size: 1,
+      keep_alive: '1ms'
+    )
+
+    scroll_enumerator.request_more_hits
+    index.delete_scroll(scroll_enumerator.scroll_id)
+    assert_raises ElasticRecord::ExpiredScrollError do
+      scroll_enumerator.request_more_hits
+    end
+  end
+
+  def test_each_slice
+    10.times { |i| index.index_document("bob#{i}", color: 'red') }
+    batches = []
+
+    scroll_enumerator = index.build_scroll_enumerator(search: {'query' => {query_string: {query: 'color:red'}}}, batch_size: 1)
+
+    scroll_enumerator.each_slice do |slice|
+      batches << slice
+    end
+
+    assert_equal 10, batches.size
+
+    # Assert context was removed
+    assert_raises ElasticRecord::ExpiredScrollError do
+      scroll_enumerator.request_more_hits
+    end
+  end
+
+  def test_invalid_scroll_error
+    assert_raises ElasticRecord::InvalidScrollError do
+      index.scroll('invalid', '1m')
+    end
+  end
+
+  private
+
+    def index
+      @index ||= Widget.elastic_index
+    end
+end


### PR DESCRIPTION
Enables `Document.multi_search([query1, query2])`. Mirrors the `search` method above it.