### PR TITLE
Remove type param/routing in indexing docs/search

### DIFF
--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -89,7 +89,7 @@ module ElasticRecord
 
     def get(end_path, json = nil)
       path = "/#{alias_name}"
-      path += "/#{mapping_type}"
+      path += "/#{mapping_type}" if custom_mapping_type_name?
       path += "/#{end_path}"
 
       connection.json_get path, json

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -25,13 +25,13 @@ module ElasticRecord
 
       def index_document(id, document, parent: nil, index_name: alias_name)
         if batch = current_bulk_batch
-          instructions = { _index: index_name, _type: mapping_type, _id: id }
+          instructions = { _index: index_name, _id: id }
           instructions[:parent] = parent if parent
 
           batch << { index: instructions }
           batch << document
         else
-          path = "/#{index_name}/#{mapping_type}/#{id}"
+          path = "/#{index_name}/_doc/#{id}"
           path << "?parent=#{parent}" if parent
 
           if id
@@ -47,13 +47,13 @@ module ElasticRecord
         params = {doc: document, doc_as_upsert: true}
 
         if batch = current_bulk_batch
-          instructions = { _index: index_name, _type: mapping_type, _id: id, retry_on_conflict: 3 }
+          instructions = { _index: index_name, _id: id, retry_on_conflict: 3 }
           instructions[:parent] = parent if parent
 
           batch << { update: instructions }
           batch << params
         else
-          path = "/#{index_name}/#{mapping_type}/#{id}/_update?retry_on_conflict=3"
+          path = "/#{index_name}/_doc/#{id}/_update?retry_on_conflict=3"
           path << "&parent=#{parent}" if parent
 
           connection.json_post path, params
@@ -65,11 +65,11 @@ module ElasticRecord
         index_name ||= alias_name
 
         if batch = current_bulk_batch
-          instructions = { _index: index_name, _type: mapping_type, _id: id, retry_on_conflict: 3 }
+          instructions = { _index: index_name, _id: id, retry_on_conflict: 3 }
           instructions[:parent] = parent if parent
           batch << { delete: instructions }
         else
-          path = "/#{index_name}/#{mapping_type}/#{id}"
+          path = "/#{index_name}/_doc/#{id}"
           path << "&parent=#{parent}" if parent
 
           connection.json_delete path

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -49,7 +49,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     index.update_document('abc', color: 'blue')
 
     expected = {'warehouse_id' => '5', 'color' => 'blue'}
-    assert_equal expected, index.get('abc', index.mapping_type)['_source']
+    assert_equal expected, index.get('abc')['_source']
 
     assert_raises RuntimeError do
       index.update_document(nil, color: 'blue')
@@ -87,11 +87,11 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
       index.delete_document '3'
 
       expected = [
-        {index: {_index: index.alias_name, _type: "widget", _id: "5"}},
+        {index: {_index: index.alias_name, _id: "5"}},
         {color: "green"},
-        {update: {_index: "widgets", _type: "widget", _id: "5", retry_on_conflict: 3}},
+        {update: {_index: "widgets", _id: "5", retry_on_conflict: 3}},
         {doc: {color: "blue"}, doc_as_upsert: true},
-        {delete: {_index: index.alias_name, _type: "widget", _id: "3", retry_on_conflict: 3}}
+        {delete: {_index: index.alias_name, _id: "3", retry_on_conflict: 3}}
       ]
       assert_equal expected, index.current_bulk_batch
     end
@@ -151,7 +151,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
         InheritedWidget.elastic_index.index_document '5', color: 'green'
 
         expected = [
-          {index: {_index: index.alias_name, _type: "widget", _id: "5"}},
+          {index: {_index: index.alias_name, _id: "5"}},
           {color: "green"}
         ]
         assert_equal expected, index.current_bulk_batch


### PR DESCRIPTION
Deprecated/gone in 7+, not needed in 6. Since Data Axle is already not using and/or reliant on this, start stripping the rest of it out.

There's still some alternative uses that mapping_type serves for has_child queries and such, so I can't completely remove all of it as I'd like, but this will at least get rid of some observed ES7 deprecation warnings.