### PR TITLE
Add es6 mode; use _type in bulk requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: xenial
 
 before_install:
 - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
-- tar -xzf elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz
+- tar -xzf elasticsearch-${ES_VERSION}.tar.gz
 - ./elasticsearch-${ES_VERSION}/bin/elasticsearch -d
 
 before_script:
@@ -14,7 +14,7 @@ before_script:
 - bundle exec rake app:index:reset
 
 env:
-  global:
+  matrix:
   - ES_VERSION=6.8.2
   - ES_VERSION=7.1.1-linux-x86_64
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 dist: xenial
 
 before_install:
-- wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz
+- wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
 - tar -xzf elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz
 - ./elasticsearch-${ES_VERSION}/bin/elasticsearch -d
 
@@ -15,7 +15,8 @@ before_script:
 
 env:
   global:
-  - ES_VERSION=7.1.1
+  - ES_VERSION=6.8.2
+  - ES_VERSION=7.1.1-linux-x86_64
 
 services:
 - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache: bundler
 dist: xenial
 
 before_install:
-- wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
-- tar -xzf elasticsearch-${ES_VERSION}.tar.gz
+- wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}${ES_VERSION_PATH}.tar.gz
+- tar -xzf elasticsearch-${ES_VERSION}${ES_VERSION_PATH}.tar.gz
 - ./elasticsearch-${ES_VERSION}/bin/elasticsearch -d
 
 before_script:
@@ -16,7 +16,8 @@ before_script:
 env:
   matrix:
   - ES_VERSION=6.8.2
-  - ES_VERSION=7.1.1-linux-x86_64
+  - ES_VERSION=7.1.1
+    ES_VERSION_PATH=-linux-x86_64
 
 services:
 - postgresql

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ development:
 
 ## ElasticSearch 6.x Compatibility ##
 
-In order to work correctly set the config option `set es6_mode` to true.
+In order to work correctly set the config option `es6_mode` to true.
 ```ruby
 # config/initializers/elastic_search.rb
 ElasticRecord.configure do |config|

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ end
 
 ```yaml
 # config/elasticsearch.yml:
-```yaml
 development:
   servers: es1.example.com:9200
   timeout: 10
@@ -36,7 +35,7 @@ development:
 
 ## ElasticSearch 6.x Compatibility ##
 
-In order to work correctly set the config option `set es6`_mode to true.
+In order to work correctly set the config option `set es6_mode` to true.
 ```ruby
 # config/initializers/elastic_search.rb
 ElasticRecord.configure do |config|
@@ -203,9 +202,9 @@ class Product
 end
 ```
 
-Mapping types are removed in ElasticSearch 7.x. While you can still set
-mapping type most associated behaviors have since been removed. When used with
-ElasticSearch 6.x, this gem will use '_doc'.
+Mapping types are removed in ElasticSearch 7.x. While you can still set mapping type, most
+associated behaviors have since been removed. When used with ElasticSearch 6.x, this gem will use
+'_doc'.
 
 ```ruby
 class Product

--- a/README.md
+++ b/README.md
@@ -27,10 +27,21 @@ end
 
 ```yaml
 # config/elasticsearch.yml:
+```yaml
 development:
   servers: es1.example.com:9200
   timeout: 10
   retries: 2
+```
+
+## ElasticSearch 6.x Compatibility ##
+
+In order to work correctly set the config option `set es6`_mode to true.
+```ruby
+# config/initializers/elastic_search.rb
+ElasticRecord.configure do |config|
+  config.es6_mode = true
+end
 ```
 
 ## Search API ##
@@ -192,7 +203,9 @@ class Product
 end
 ```
 
-Mapping types will be removed in ElasticSearch 7.x.  To rename the default mapping type (`_doc`), use `elastic_index.mapping_type`:
+Mapping types are removed in ElasticSearch 7.x. While you can still set
+mapping type most associated behaviors have since been removed. When used with
+ElasticSearch 6.x, this gem will use '_doc'.
 
 ```ruby
 class Product

--- a/README.md
+++ b/README.md
@@ -33,16 +33,6 @@ development:
   retries: 2
 ```
 
-## ElasticSearch 6.x Compatibility ##
-
-In order to work correctly set the config option `es6_mode` to true.
-```ruby
-# config/initializers/elastic_search.rb
-ElasticRecord.configure do |config|
-  config.es6_mode = true
-end
-```
-
 ## Search API ##
 
 ElasticRecord adds the method 'elastic_search' to your models. It works similar to active_record scoping:

--- a/README.md
+++ b/README.md
@@ -192,18 +192,6 @@ class Product
 end
 ```
 
-Mapping types are removed in ElasticSearch 7.x. While you can still set mapping type, most
-associated behaviors have since been removed. When used with ElasticSearch 6.x, this gem will use
-'_doc'.
-
-```ruby
-class Product
-  include ElasticRecord::Model
-
-  elastic_index.mapping_type = 'product'
-end
-```
-
 ### Inheritance
 
 When one model inherits from another, ElasticRecord makes some assumptions about how the child index should be configured.  By default:

--- a/lib/elastic_record.rb
+++ b/lib/elastic_record.rb
@@ -17,6 +17,7 @@ module ElasticRecord
   autoload :Relation
   autoload :Searching
   autoload :SearchHits
+  autoload :Version
 
   module AggregationResponse
     extend ActiveSupport::Autoload

--- a/lib/elastic_record.rb
+++ b/lib/elastic_record.rb
@@ -12,6 +12,7 @@ module ElasticRecord
   autoload :FromSearchHit
   autoload :Index
   autoload :Lucene
+  autoload :ElasticConnection
   autoload :Model
   autoload :PercolatorModel
   autoload :Relation

--- a/lib/elastic_record/config.rb
+++ b/lib/elastic_record/config.rb
@@ -7,6 +7,7 @@ module ElasticRecord
     class_attribute :model_names,            default: []
     class_attribute :scroll_keep_alive,      default: '2m'
     class_attribute :index_suffix
+    class_attribute :es6_mode,               default: false
 
     class << self
       def models
@@ -31,6 +32,10 @@ module ElasticRecord
 
         if settings['scroll_keep_alive'].present?
           self.scroll_keep_alive = settings['scroll_keep_alive']
+        end
+
+        if settings['es6_mode'].present?
+          self.es6_mode = settings['es6_mode']
         end
       end
     end

--- a/lib/elastic_record/config.rb
+++ b/lib/elastic_record/config.rb
@@ -7,7 +7,6 @@ module ElasticRecord
     class_attribute :model_names,            default: []
     class_attribute :scroll_keep_alive,      default: '2m'
     class_attribute :index_suffix
-    class_attribute :es6_mode,               default: false
 
     class << self
       def models
@@ -32,10 +31,6 @@ module ElasticRecord
 
         if settings['scroll_keep_alive'].present?
           self.scroll_keep_alive = settings['scroll_keep_alive']
-        end
-
-        if settings['es6_mode'].present?
-          self.es6_mode = settings['es6_mode']
         end
       end
     end

--- a/lib/elastic_record/elastic_connection.rb
+++ b/lib/elastic_record/elastic_connection.rb
@@ -1,7 +1,14 @@
 module ElasticRecord
   module ElasticConnection
-    def elastic_connection
-      self.elastic_connection_cache ||= ElasticRecord::Connection.new(ElasticRecord::Config.servers, ElasticRecord::Config.connection_options)
+    extend ActiveSupport::Concern
+    included do
+      mattr_accessor :elastic_connection_cache, instance_writer: false
+    end
+
+    class_methods do
+      def elastic_connection
+        self.elastic_connection_cache ||= ElasticRecord::Connection.new(ElasticRecord::Config.servers, ElasticRecord::Config.connection_options)
+      end
     end
   end
 end

--- a/lib/elastic_record/elastic_connection.rb
+++ b/lib/elastic_record/elastic_connection.rb
@@ -1,0 +1,7 @@
+module ElasticRecord
+  module ElasticConnection
+    def elastic_connection
+      self.elastic_connection_cache ||= ElasticRecord::Connection.new(ElasticRecord::Config.servers, ElasticRecord::Config.connection_options)
+    end
+  end
+end

--- a/lib/elastic_record/elastic_connection.rb
+++ b/lib/elastic_record/elastic_connection.rb
@@ -1,6 +1,7 @@
 module ElasticRecord
   module ElasticConnection
     extend ActiveSupport::Concern
+
     included do
       mattr_accessor :elastic_connection_cache, instance_writer: false
     end

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -88,9 +88,7 @@ module ElasticRecord
     end
 
     def get(end_path, json = nil)
-      path = "/#{alias_name}"
-      path += "/#{mapping_type}" if ElasticRecord::Config.es6_mode
-      path += "/#{end_path}"
+      path = "/#{alias_name}/_doc/#{end_path}"
 
       connection.json_get path, json
     end

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -89,7 +89,7 @@ module ElasticRecord
 
     def get(end_path, json = nil)
       path = "/#{alias_name}"
-      path += "/#{mapping_type}" if custom_mapping_type_name?
+      path += "/#{mapping_type}" if ElasticRecord::Config.es6_mode
       path += "/#{end_path}"
 
       connection.json_get path, json

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -88,15 +88,11 @@ module ElasticRecord
     end
 
     def get(end_path, json = nil)
-      path = "/#{alias_name}/#{end_path}"
-
-      connection.json_get path, json
+      connection.json_get("/#{alias_name}/#{end_path}", json)
     end
 
     def get_doc(end_path, json = nil)
-      path = "/#{alias_name}/_doc/#{end_path}"
-
-      connection.json_get path, json
+      connection.json_get("/#{alias_name}/_doc/#{end_path}", json)
     end
 
     private

--- a/lib/elastic_record/index.rb
+++ b/lib/elastic_record/index.rb
@@ -88,6 +88,12 @@ module ElasticRecord
     end
 
     def get(end_path, json = nil)
+      path = "/#{alias_name}/#{end_path}"
+
+      connection.json_get path, json
+    end
+
+    def get_doc(end_path, json = nil)
       path = "/#{alias_name}/_doc/#{end_path}"
 
       connection.json_get path, json

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -26,7 +26,7 @@ module ElasticRecord
       def index_document(id, document, parent: nil, index_name: alias_name)
         if batch = current_bulk_batch
           instructions = { _index: index_name, _id: id }
-          instructions[:_type] = '_doc' if ElasticRecord::Config.es6_mode
+          instructions[:_type] = '_doc' if ElasticRecord::Version.es6?
           instructions[:parent] = parent if parent
 
           batch << { index: instructions }
@@ -49,7 +49,7 @@ module ElasticRecord
 
         if batch = current_bulk_batch
           instructions = { _index: index_name, _id: id, retry_on_conflict: 3 }
-          instructions[:_type] = '_doc' if ElasticRecord::Config.es6_mode
+          instructions[:_type] = '_doc' if ElasticRecord::Version.es6?
           instructions[:parent] = parent if parent
 
           batch << { update: instructions }
@@ -68,7 +68,7 @@ module ElasticRecord
 
         if batch = current_bulk_batch
           instructions = { _index: index_name, _id: id, retry_on_conflict: 3 }
-          instructions[:_type] = '_doc' if ElasticRecord::Config.es6_mode
+          instructions[:_type] = '_doc' if ElasticRecord::Version.es6?
           instructions[:parent] = parent if parent
           batch << { delete: instructions }
         else

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -26,6 +26,7 @@ module ElasticRecord
       def index_document(id, document, parent: nil, index_name: alias_name)
         if batch = current_bulk_batch
           instructions = { _index: index_name, _id: id }
+          instructions[:_type] = '_doc' if ElasticRecord::Config.es6_mode
           instructions[:parent] = parent if parent
 
           batch << { index: instructions }
@@ -48,6 +49,7 @@ module ElasticRecord
 
         if batch = current_bulk_batch
           instructions = { _index: index_name, _id: id, retry_on_conflict: 3 }
+          instructions[:_type] = '_doc' if ElasticRecord::Config.es6_mode
           instructions[:parent] = parent if parent
 
           batch << { update: instructions }
@@ -66,6 +68,7 @@ module ElasticRecord
 
         if batch = current_bulk_batch
           instructions = { _index: index_name, _id: id, retry_on_conflict: 3 }
+          instructions[:_type] = '_doc' if ElasticRecord::Config.es6_mode
           instructions[:parent] = parent if parent
           batch << { delete: instructions }
         else

--- a/lib/elastic_record/index/manage.rb
+++ b/lib/elastic_record/index/manage.rb
@@ -9,12 +9,12 @@ module ElasticRecord
 
       def create(index_name = new_index_name, setting_overrides: {})
         mapping_params = {
-          "mappings" => (custom_mapping_type_name? ? { mapping_type => mapping } : mapping),
+          "mappings" => mapping,
           "settings" => settings.merge(setting_overrides)
         }
 
         # TODO: Remove include_type_name when ES8 support is added
-        connection.json_put "/#{index_name}?include_type_name=#{custom_mapping_type_name?}", mapping_params
+        connection.json_put "/#{index_name}?include_type_name=false", mapping_params
         index_name
       end
 

--- a/lib/elastic_record/index/mapping_type.rb
+++ b/lib/elastic_record/index/mapping_type.rb
@@ -15,10 +15,6 @@ module ElasticRecord
       def mapping_type
         @mapping_type || DEFAULT_MAPPING_TYPE
       end
-
-      def custom_mapping_type_name?
-        mapping_type != MappingType::DEFAULT_MAPPING_TYPE
-      end
     end
   end
 end

--- a/lib/elastic_record/index/search.rb
+++ b/lib/elastic_record/index/search.rb
@@ -60,7 +60,7 @@ module ElasticRecord
 
     module Search
       def record_exists?(id)
-        get(id)['found']
+        get_doc(id)['found']
       end
 
       def search(elastic_query, options = {})

--- a/lib/elastic_record/model.rb
+++ b/lib/elastic_record/model.rb
@@ -6,6 +6,7 @@ module ElasticRecord
       extend Searching
       extend ClassMethods
       extend FromSearchHit
+      extend ElasticConnection
       include Callbacks
       include AsDocument
 
@@ -34,10 +35,6 @@ module ElasticRecord
 
       def elastic_index=(index)
         @elastic_index = index
-      end
-
-      def elastic_connection
-        self.elastic_connection_cache ||= ElasticRecord::Connection.new(ElasticRecord::Config.servers, ElasticRecord::Config.connection_options)
       end
     end
 

--- a/lib/elastic_record/model.rb
+++ b/lib/elastic_record/model.rb
@@ -4,17 +4,15 @@ module ElasticRecord
 
     included do
       extend Searching
-      extend ClassMethods
       extend FromSearchHit
-      extend ElasticConnection
+      include ElasticConnection
       include Callbacks
       include AsDocument
 
       singleton_class.delegate :query, :filter, :aggregate, to: :elastic_search
-      mattr_accessor :elastic_connection_cache, instance_writer: false
     end
 
-    module ClassMethods
+    class_methods do
       def inherited(child)
         super
 

--- a/lib/elastic_record/version.rb
+++ b/lib/elastic_record/version.rb
@@ -1,0 +1,11 @@
+module ElasticRecord
+  class Version
+    include Model
+
+    def self.es6?
+      @es6_mode ||= elastic_connection.json_get('/')
+        .dig('version', 'number')
+        .start_with?('6.')
+    end
+  end
+end

--- a/lib/elastic_record/version.rb
+++ b/lib/elastic_record/version.rb
@@ -1,11 +1,11 @@
 module ElasticRecord
   class Version
-    include Model
+    extend ElasticConnection
 
     def self.es6?
-      @es6_mode ||= elastic_connection.json_get('/')
+      @es6 ||= elastic_connection.json_get('/')
         .dig('version', 'number')
-        .start_with?('6.')
+        &.start_with?('6.')
     end
   end
 end

--- a/lib/elastic_record/version.rb
+++ b/lib/elastic_record/version.rb
@@ -1,6 +1,6 @@
 module ElasticRecord
   class Version
-    extend ElasticConnection
+    include ElasticConnection
 
     def self.es6?
       @es6 ||= elastic_connection.json_get('/')

--- a/test/dummy/app/models/warehouse.rb
+++ b/test/dummy/app/models/warehouse.rb
@@ -1,7 +1,6 @@
 class Warehouse < ActiveRecord::Base
   include ElasticRecord::Model
 
-  elastic_index.mapping_type = 'warehouse'
   elastic_index.mapping[:properties].update(
     'name' => { type: 'keyword' }
   )

--- a/test/dummy/app/models/widget.rb
+++ b/test/dummy/app/models/widget.rb
@@ -10,7 +10,6 @@ class Widget < ActiveRecord::Base
     attr_accessor :name
   end
 
-  self.elastic_index.mapping_type = 'widget'
   self.elastic_index.mapping[:properties].update(
     'name' => {
       type: 'text',

--- a/test/dummy/app/models/widget_query.rb
+++ b/test/dummy/app/models/widget_query.rb
@@ -4,7 +4,6 @@ class WidgetQuery
   define_attributes [:name, :color]
 
   self.percolates_model = Widget
-  self.elastic_index.mapping_type = 'widget'
 
   def as_search_document
     filters = {}

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -87,11 +87,11 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
       index.delete_document '3'
 
       expected = [
-        {index: add_version_params({_index: index.alias_name, _id: "5"})},
+        {index: add_es6_params({_index: index.alias_name, _id: "5"})},
         {color: "green"},
-        {update: add_version_params({_index: "widgets", _id: "5", retry_on_conflict: 3})},
+        {update: add_es6_params({_index: "widgets", _id: "5", retry_on_conflict: 3})},
         {doc: {color: "blue"}, doc_as_upsert: true},
-        {delete: add_version_params({_index: index.alias_name, _id: "3", retry_on_conflict: 3})}
+        {delete: add_es6_params({_index: index.alias_name, _id: "3", retry_on_conflict: 3})}
       ]
 
       assert_equal expected, index.current_bulk_batch
@@ -152,7 +152,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
         InheritedWidget.elastic_index.index_document '5', color: 'green'
 
         expected = [
-          {index: add_version_params({_index: index.alias_name, _id: "5"})},
+          {index: add_es6_params({_index: index.alias_name, _id: "5"})},
           {color: "green"}
         ]
 
@@ -164,7 +164,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
 
   private
 
-    def add_version_params(hash)
+    def add_es6_params(hash)
       ElasticRecord::Version.es6? ? hash.merge!(_type: '_doc') : hash
     end
 

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -99,32 +99,6 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     assert_nil index.current_bulk_batch
   end
 
-
-  def test_bulk_es6_mode
-    ElasticRecord::Config.es6_mode = true
-    assert_nil index.current_bulk_batch
-
-    index.bulk do
-      index.index_document '5', color: 'green'
-      index.update_document '5', color: 'blue'
-      index.delete_document '3'
-
-      expected = [
-        {index: {_index: index.alias_name, _id: "5", _type: "_doc"}},
-        {color: "green"},
-        {update: {_index: "widgets", _id: "5", retry_on_conflict: 3, _type: "_doc"}},
-        {doc: {color: "blue"}, doc_as_upsert: true},
-        {delete: {_index: index.alias_name, _id: "3", retry_on_conflict: 3, _type: "_doc"}}
-      ]
-
-      ElasticRecord::Config.es6_mode = false
-
-      assert_equal expected, index.current_bulk_batch
-    end
-
-    assert_nil index.current_bulk_batch
-  end
-
   def test_bulk_nested
     expected_warehouse_count = Warehouse.count + 2
 

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -49,7 +49,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     index.update_document('abc', color: 'blue')
 
     expected = {'warehouse_id' => '5', 'color' => 'blue'}
-    assert_equal expected, index.get('abc')['_source']
+    assert_equal expected, index.get_doc('abc')['_source']
 
     assert_raises RuntimeError do
       index.update_document(nil, color: 'blue')

--- a/test/elastic_record/index/mapping_type_test.rb
+++ b/test/elastic_record/index/mapping_type_test.rb
@@ -8,6 +8,7 @@ class ElasticRecord::Index::MappingTypeTest < MiniTest::Test
   def test_writer
     index.mapping_type = 'widget'
     assert_equal 'widget', index.mapping_type
+    index.mapping_type = '_doc'
   end
 
   private

--- a/test/elastic_record/model_test.rb
+++ b/test/elastic_record/model_test.rb
@@ -22,7 +22,7 @@ class ElasticRecord::ModelTest < MiniTest::Test
     assert_equal Widget.elastic_index.mapping_type, InheritedModel.elastic_index.mapping_type
     assert_equal 'widgets', InheritedModel.elastic_index.alias_name
     assert_equal InheritedModel, InheritedModel.elastic_index.model
-    assert_equal 'widget', InheritedModel.elastic_index.mapping_type
+    assert_equal '_doc', InheritedModel.elastic_index.mapping_type
   end
 
   def test_index_to_elasticsearch


### PR DESCRIPTION
Unfortunately, I had missed a bit where the bulk api in ES6 requires type parameters hard stop. (You can provide them in the routing as well). Teaches me to not run the tests on both versions 🤦‍♂️.

~I'm not committed to merging this. elastic_record 5.6.0 can run in both versions (ES6.X & 7.X) though it will produce more deprecation warnings in 7.X.~ Feeling much better about where this is going. We can mostly get rid of mapping_type entirely just hard code '_doc' where appropriate now.