### PR TITLE
Ensure relations return full total of hits

### DIFF
--- a/lib/elastic_record/relation/hits.rb
+++ b/lib/elastic_record/relation/hits.rb
@@ -13,7 +13,7 @@ module ElasticRecord
 
       def search_results
         @search_results ||= begin
-          options = { typed_keys: true }
+          options = { typed_keys: true, track_total_hits: true }
           options[:search_type] = search_type_value if search_type_value
           options[:_source] = klass.elastic_index.load_from_source
 


### PR DESCRIPTION
ElasticSearch introduced a new feature where a search has the total
limited to 10k by default for all requests. While this might make sense
for some usages, elastic_record is designed to be an ORM. You wouldn't
expect a SQL COUNT to lie to you unless you gave it a magic word.