### PR TITLE
Use new update api path

### DIFF
--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -53,7 +53,7 @@ module ElasticRecord
           batch << { update: instructions }
           batch << params
         else
-          path = "/#{index_name}/_doc/#{id}/_update?retry_on_conflict=3"
+          path = "/#{index_name}/_update/#{id}?retry_on_conflict=3"
           path << "&parent=#{parent}" if parent
 
           connection.json_post path, params


### PR DESCRIPTION
Elasticsearch changed this path in 7 to /{index}/_update/{id}

Resolves the deprecation warning:
```
[types removal] Specifying types in document update requests is deprecated, use the endpoint /{index}/_update/{id} instead.
```