### PR TITLE
Ensure that nested objects are fully indexed when a root document is partially updated

### DIFF
--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -1,10 +1,10 @@
 module ElasticRecord
   module AsDocument
-    def as_search_document(mapping_properties = elastic_index.mapping[:properties])
+    def as_search_document(mapping_properties = elastic_index.mapping[:properties], nested_document: false)
       mapping_properties.each_with_object({}) do |(field, mapping), result|
         value = value_for_elastic_search field, mapping, mapping_properties
 
-        unless value.nil?
+        if (!value.nil? || nested_document)
           result[field] = value
         end
       end
@@ -40,7 +40,7 @@ module ElasticRecord
     end
 
     def value_for_elastic_search_object(object, nested_mapping)
-      object.respond_to?(:as_search_document) ? object.as_search_document(nested_mapping) : object
+      object.respond_to?(:as_search_document) ? object.as_search_document(nested_mapping, nested_document: true) : object
     end
 
     def value_for_elastic_search_range(range)

--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -1,10 +1,10 @@
 module ElasticRecord
   module AsDocument
-    def as_search_document(mapping_properties = elastic_index.mapping[:properties], nested_document: false)
+    def as_search_document(mapping_properties = elastic_index.mapping[:properties], is_inner_object: false)
       mapping_properties.each_with_object({}) do |(field, mapping), result|
         value = value_for_elastic_search field, mapping, mapping_properties
 
-        if (!value.nil? || nested_document)
+        if (!value.nil? || is_inner_object)
           result[field] = value
         end
       end
@@ -40,7 +40,7 @@ module ElasticRecord
     end
 
     def value_for_elastic_search_object(object, nested_mapping)
-      object.respond_to?(:as_search_document) ? object.as_search_document(nested_mapping, nested_document: true) : object
+      object.respond_to?(:as_search_document) ? object.as_search_document(nested_mapping, is_inner_object: true) : object
     end
 
     def value_for_elastic_search_range(range)


### PR DESCRIPTION
**Problem**

#107 introduced a regression where inner object fields being set to nil were not being indexed as null.

**Solution**

Ensure all mapped fields are always specified for every inner object, whether the root document is being wholly- or partially-indexed.