### PR TITLE
Fix nested object indexing

### DIFF
--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -26,7 +26,7 @@ module ElasticRecord
       case mapping[:type]&.to_sym
       when :object
         object_mapping_properties = mapping_properties.dig(field, :properties)
-        value_for_elastic_search_object(value, object_mapping_properties)
+        value_for_elastic_search_object(value, object_mapping_properties, is_inner_object: true)
       when :nested
         return if value.empty?
 
@@ -39,8 +39,8 @@ module ElasticRecord
       end
     end
 
-    def value_for_elastic_search_object(object, nested_mapping)
-      object.respond_to?(:as_search_document) ? object.as_search_document(nested_mapping, is_inner_object: true) : object
+    def value_for_elastic_search_object(object, nested_mapping, is_inner_object: nil)
+      object.respond_to?(:as_search_document) ? object.as_search_document(nested_mapping, is_inner_object: is_inner_object) : object
     end
 
     def value_for_elastic_search_range(range)

--- a/test/dummy/app/models/mock_model.rb
+++ b/test/dummy/app/models/mock_model.rb
@@ -34,8 +34,8 @@ module MockModel
       record
     end
 
-    def define_attributes(attributes)
-      define_attribute_methods attributes
+    def define_attributes(*attributes)
+      define_attribute_methods *attributes
 
       attributes.each do |attribute|
         define_method attribute do

--- a/test/dummy/app/models/widget_query.rb
+++ b/test/dummy/app/models/widget_query.rb
@@ -1,7 +1,7 @@
 class WidgetQuery
   include TestPercolatorModel
 
-  define_attributes [:name, :color]
+  define_attributes :name, :color
 
   self.percolates_model = Widget
 

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -30,31 +30,31 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
 
   class SpecialFieldsModel
     include TestModel
-    attr_accessor :author, :book_length, :commenters, :meta,
+    define_attributes :author, :book_length, :commenters, :meta
 
     class Author
       include TestModel
-      attr_accessor :name, :salary_estimate
+      define_attributes :name, :salary_estimate
 
       def self.mapping_properties
         {
-          name: { type: :string },
-          salary_estimate: { type: :integer_range }
+          'name' => { type: :string },
+          'salary_estimate' => { type: :integer_range }
         }
       end
     end
 
     self.elastic_index.mapping[:properties].update(
-      author:      {
+      'author' => {
         type: :object,
         properties: Author.mapping_properties
       },
-      commenters:  {
+      'commenters' => {
         type: :nested,
         properties: Author.mapping_properties
       },
-      meta:        { type: "object" },
-      book_length: { type: :integer_range }
+      'meta' => { type: "object" },
+      'book_length' => { type: :integer_range }
     )
   end
 

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -73,29 +73,42 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
 
     doc = record.as_search_document
 
-    assert_equal({name: 'Jonny', salary_estimate: { 'gte' => 250, 'lte' => nil }}, doc[:author])
-    expected_commenter = { name: 'Jonny', salary_estimate: nil }
-    assert_equal([expected_commenter, expected_commenter], doc[:commenters])
-    assert_equal({some: 'value'}, doc[:meta])
+    expected_author = {
+      'name' => 'Jonny',
+      'salary_estimate' => { 'gte' => 250, 'lte' => nil }
+    }
+    assert_equal(expected_author, doc['author'])
+    expected_commenter = { 'name' => 'Jonny' }
+    assert_equal([expected_commenter, expected_commenter], doc['commenters'])
+    assert_equal({ some: 'value'}, doc['meta'])
   end
 
   def test_as_search_document_with_range_fields
     record = SpecialFieldsModel.new(book_length: 250..500)
     doc = record.as_search_document
-    assert_equal({ "gte" => 250, "lte" => 500 }, doc[:book_length])
+    assert_equal({ "gte" => 250, "lte" => 500 }, doc['book_length'])
 
     record = SpecialFieldsModel.new(book_length: -Float::INFINITY..500)
     doc = record.as_search_document
-    assert_equal({ "gte" => nil, "lte" => 500 }, doc[:book_length])
+    assert_equal({ "gte" => nil, "lte" => 500 }, doc['book_length'])
 
     record = SpecialFieldsModel.new(book_length: 250..Float::INFINITY)
     doc = record.as_search_document
-    assert_equal({ "gte" => 250, "lte" => nil }, doc[:book_length])
+    assert_equal({ "gte" => 250, "lte" => nil }, doc['book_length'])
   end
 
   def test_as_search_document_with_invalid_range_fields
     record = SpecialFieldsModel.new(book_length: 500..250)
     invalid_elasticsearch_doc = record.as_search_document
-    assert_equal({ "gte" => 500, "lte" => 250 }, invalid_elasticsearch_doc[:book_length])
+    assert_equal({ "gte" => 500, "lte" => 250 }, invalid_elasticsearch_doc['book_length'])
+  end
+
+  def test_as_partial_update_document_with_special_fields
+    record = SpecialFieldsModel.create
+    record.author = SpecialFieldsModel::Author.new(name: 'Johnny')
+    doc = record.as_partial_update_document
+
+    expected_commenter = { 'name' => 'Johnny', 'salary_estimate' => nil }
+    assert_equal expected_commenter, doc['author']
   end
 end

--- a/test/elastic_record/callbacks_test.rb
+++ b/test/elastic_record/callbacks_test.rb
@@ -29,7 +29,7 @@ class ElasticRecord::CallbacksTest < MiniTest::Test
   class DisablingModel
     include TestModel
 
-    define_attributes [:height]
+    define_attributes :height
 
     self.elastic_index.mapping[:properties].update(
       height: {


### PR DESCRIPTION
**Problem**

#111 accidentally introduced behavior where nested definitions were also being fully index when the parent document was being partially updated.

**Solution**

Ensure that only objects are fully indexed during a partial update, not nested types.