### PR TITLE
Use ruby 2.6 boundless ranges

### DIFF
--- a/lib/elastic_record/as_document.rb
+++ b/lib/elastic_record/as_document.rb
@@ -45,7 +45,7 @@ module ElasticRecord
 
     def value_for_elastic_search_range(range)
       gte = range.begin unless range.begin == -Float::INFINITY
-      lte = range.end unless range.end == Float::INFINITY
+      lte = range.end
 
       {'gte' => gte, 'lte' => lte}
     end

--- a/lib/elastic_record/from_search_hit.rb
+++ b/lib/elastic_record/from_search_hit.rb
@@ -51,7 +51,6 @@ module ElasticRecord
 
       def value_for_range(value)
         value['gte'] = -Float::INFINITY if value['gte'].nil?
-        value['lte'] =  Float::INFINITY if value['lte'].nil?
         value['gte']..value['lte']
       end
 

--- a/test/elastic_record/as_document_test.rb
+++ b/test/elastic_record/as_document_test.rb
@@ -65,7 +65,7 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
 
   def test_as_search_document_with_special_fields
     record = SpecialFieldsModel.new(meta: { some: "value" })
-    record.author = SpecialFieldsModel::Author.new(name: 'Jonny', salary_estimate: 250..Float::INFINITY)
+    record.author = SpecialFieldsModel::Author.new(name: 'Jonny', salary_estimate: (250..))
     record.commenters = [
       SpecialFieldsModel::Author.new(name: 'Jonny'),
       SpecialFieldsModel::Author.new(name: 'Jonny')
@@ -92,7 +92,7 @@ class ElasticRecord::AsDocumentTest < MiniTest::Test
     doc = record.as_search_document
     assert_equal({ "gte" => nil, "lte" => 500 }, doc['book_length'])
 
-    record = SpecialFieldsModel.new(book_length: 250..Float::INFINITY)
+    record = SpecialFieldsModel.new(book_length: (250..))
     doc = record.as_search_document
     assert_equal({ "gte" => 250, "lte" => nil }, doc['book_length'])
   end


### PR DESCRIPTION
[Basecamp TODO](https://3.basecamp.com/4119850/buckets/9653296/todos/2293987115)

### Problem

Elastic Record checks for ranges with Float::INFINITY as their upper bounds. However, content system no longer uses ranges with Float::INFINITY as the upper bound.

### Solution

Remove handlers for ranges with Float::INFINITY as the upper bound.

### Status

This is in use by content system on QA3.