### PR TITLE
Hackable Relation

### DIFF
--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -193,8 +193,8 @@ module ElasticRecord
         end
 
         def build_query_and_filter
-          query = build_query
-          filter = build_filter
+          query = build_search_query
+          filter = build_search_filter
 
           query_and_filter = if filter
             arelastic.queries.bool(filter: filter, must: query)
@@ -207,7 +207,7 @@ module ElasticRecord
           Arelastic::Searches::Query.new query_and_filter
         end
 
-        def build_query
+        def build_search_query
           if query_value.is_a?(String)
             Arelastic::Queries::QueryString.new query_value
           else
@@ -215,8 +215,12 @@ module ElasticRecord
           end
         end
 
-        def build_filter
-          nodes = build_filter_nodes(filter_values)
+        def build_search_filter
+          build_filter(filter_values)
+        end
+
+        def build_filter(filters)
+          nodes = build_filter_nodes(filters)
 
           if nodes.size == 1
             nodes.first

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -181,7 +181,7 @@ module ElasticRecord
       private
         def build_search
           searches = [
-            build_query_and_filter(query_value, filter_values),
+            build_query_and_filter,
             build_limit(limit_value),
             build_offset(offset_value),
             build_aggregations(aggregation_values),
@@ -192,9 +192,9 @@ module ElasticRecord
           Arelastic::Nodes::HashGroup.new searches
         end
 
-        def build_query_and_filter(query, filters)
-          query = build_query(query)
-          filter = build_filter(filters)
+        def build_query_and_filter
+          query = build_query
+          filter = build_filter
 
           query_and_filter = if filter
             arelastic.queries.bool(filter: filter, must: query)
@@ -207,16 +207,16 @@ module ElasticRecord
           Arelastic::Searches::Query.new query_and_filter
         end
 
-        def build_query(query)
-          if query.is_a?(String)
-            query = Arelastic::Queries::QueryString.new query
+        def build_query
+          if query_value.is_a?(String)
+            Arelastic::Queries::QueryString.new query_value
+          else
+            query_value
           end
-
-          query
         end
 
-        def build_filter(filters)
-          nodes = build_filter_nodes(filters)
+        def build_filter
+          nodes = build_filter_nodes(filter_values)
 
           if nodes.size == 1
             nodes.first


### PR DESCRIPTION
**Problem**
Modifying the behavior of query building on Relation is difficult because the methods that build the elastic record search pass in variables instead of calling them directly on the relation instance.

**Solution**
Change the method signature of `build_query_filter` to reference `filter_values` and `query_value` directly on the instance instead of passing references via variables.