### PR TITLE
Fix `where` and add `left_outer_joins`

### DIFF
--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -54,7 +54,7 @@ module ElasticRecord
       if klass.elastic_index.load_from_source
         search_hits.hits.map { |hit| klass.from_search_hit(hit) }
       else
-        klass.find search_hits.to_ids
+        klass.where(klass.primary_key => search_hits.to_ids).to_a
       end
     end
 

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -51,6 +51,7 @@ module ElasticRecord
       %i(
         includes
         joins
+        left_outer_joins
         select
         where
       ).each do |ar_method|

--- a/test/dummy/db/migrate/20200425205825_change_warehouse_id_to_int.rb
+++ b/test/dummy/db/migrate/20200425205825_change_warehouse_id_to_int.rb
@@ -1,0 +1,9 @@
+class ChangeWarehouseIdToInt < ActiveRecord::Migration[5.1]
+  def up
+    change_column :widgets, :warehouse_id, "integer USING warehouse_id::integer"
+  end
+
+  def down
+    change_column :widgets, :warehouse_id, :string
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215140125) do
+ActiveRecord::Schema.define(version: 2020_04_25_205825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20180215140125) do
   end
 
   create_table "widgets", force: :cascade do |t|
-    t.string "warehouse_id"
+    t.integer "warehouse_id"
     t.string "name"
     t.string "color"
     t.integer "price"

--- a/test/elastic_record/relation/search_methods_test.rb
+++ b/test/elastic_record/relation/search_methods_test.rb
@@ -254,6 +254,19 @@ class ElasticRecord::Relation::SearchMethodsTest < MiniTest::Test
     assert_equal widget, widgets.first
   end
 
+  def test_left_outer_joins
+    warehouse = Warehouse.create! name: 'Boeing'
+    Widget.create! name: '747', color: 'red', warehouse: warehouse
+
+    widget = Widget.create! name: 'A220', color: 'red'
+
+    widgets = relation.filter(color: 'red').left_outer_joins(:warehouse).where(warehouses: {name: nil})
+    widgets = widgets.to_a
+
+    assert_equal 1, widgets.count
+    assert_equal widget, widgets.first
+  end
+
   def test_extending_with_block
     relation.extending! do
       def foo

--- a/test/elastic_record/relation/search_methods_test.rb
+++ b/test/elastic_record/relation/search_methods_test.rb
@@ -227,6 +227,33 @@ class ElasticRecord::Relation::SearchMethodsTest < MiniTest::Test
     refute widgets.first.association(:warehouse).loaded?
   end
 
+  def test_joins
+    warehouse = Warehouse.create! name: 'Boeing'
+    Widget.create! name: '747', color: 'red', warehouse: warehouse
+
+    warehouse = Warehouse.create! name: 'Airbus'
+    Widget.create! name: 'A300', color: 'green', warehouse: warehouse
+    widget = Widget.create! name: 'A220', color: 'red', warehouse: warehouse
+
+    widgets = relation.filter(color: 'red').joins(:warehouse).where(warehouses: {name: 'Airbus'})
+    widgets = widgets.to_a
+
+    assert_equal 1, widgets.count
+    assert_equal widget, widgets.first
+  end
+
+  def test_where
+    Widget.create! name: '747', color: 'red'
+    Widget.create! name: 'A220', color: 'green'
+    widget = Widget.create! name: 'A220', color: 'red'
+
+    widgets = relation.filter(color: 'red').where(name: 'A220')
+    widgets = widgets.to_a
+
+    assert_equal 1, widgets.count
+    assert_equal widget, widgets.first
+  end
+
   def test_extending_with_block
     relation.extending! do
       def foo


### PR DESCRIPTION
Hello,

Over the week I was chatting with @kstevens715 and he mentioned that this project had an issue with the `left_outer_joins` method, so I thought I would take a look at the project.

While reviewing the project I think I found several bugs. However, I found so many bugs that I am worried I miss-understood the API of this project. Here are the issues I found:

- [ ] If where is used with filter would only work if filter already removed the correct records.
- [ ] `where` doesn't work with most of the methods in Relation::FinderMethods module. This is because the `where` is only applied in the `find_hits` & `to_a` methods.
- [ ] ElasticSearch indexes aren't cleared between tests, so the tests could step on each other.
- [ ] The test database had miss-matching data types between wearhouses.id and warehouses_id
- [ ] Order is broken now *I did this on this branch*. I'm not using find and it turns out find is order specific.