### PR TITLE
add left_outer_joins

### DIFF
--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -51,6 +51,7 @@ module ElasticRecord
       %i(
         includes
         joins
+        left_outer_joins
         select
         where
       ).each do |ar_method|

--- a/test/dummy/db/migrate/20200425205825_change_warehouse_id_to_int.rb
+++ b/test/dummy/db/migrate/20200425205825_change_warehouse_id_to_int.rb
@@ -1,0 +1,9 @@
+class ChangeWarehouseIdToInt < ActiveRecord::Migration[5.1]
+  def up
+    change_column :widgets, :warehouse_id, "integer USING warehouse_id::integer"
+  end
+
+  def down
+    change_column :widgets, :warehouse_id, :string
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215140125) do
+ActiveRecord::Schema.define(version: 2020_04_25_205825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 20180215140125) do
   end
 
   create_table "widgets", force: :cascade do |t|
-    t.string "warehouse_id"
+    t.integer "warehouse_id"
     t.string "name"
     t.string "color"
     t.integer "price"

--- a/test/elastic_record/relation/search_methods_test.rb
+++ b/test/elastic_record/relation/search_methods_test.rb
@@ -227,6 +227,17 @@ class ElasticRecord::Relation::SearchMethodsTest < MiniTest::Test
     refute widgets.first.association(:warehouse).loaded?
   end
 
+  def test_left_outer_joins
+    Widget.create! name: '747', color: 'blue'
+    widget = Widget.create! name: 'A220', color: 'red'
+
+    widgets = relation.filter(color: 'red').left_outer_joins(:warehouse).where('1=1')
+    widgets = widgets.to_a
+
+    assert_equal 1, widgets.count
+    assert_equal widget, widgets.first
+  end
+
   def test_extending_with_block
     relation.extending! do
       def foo


### PR DESCRIPTION
I was chatting with @kstevens715 this week and he mentioned that this project was having issues with running `left_outer_joins` and I thought it would be fun to try and fix the issue.

His example was `Model.filter(blah).left_outer_joins(:table).where("1=1")`. He mentioned that normally this projects lets the user chain active record methods off of the ElasticRecord::Relation.

While fixing this issue I think I found a few more issues, but I think those issues should be addressed separately.