### PR TITLE
Remove Arelastic link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ search.filter(Product.arelastic[:name].prefix("Sca").negate)
 search.filter(Product.arelastic[:size].gt(5))
 ```
 
+Helpful Arel builders can be found at https://github.com/matthuhiggins/arelastic/blob/master/lib/arelastic/builders/queries.rb.
+
 ### Querying ###
 
 To create a query string, pass a string to search.query:

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ search.filter(Product.arelastic[:name].prefix("Sca").negate)
 search.filter(Product.arelastic[:size].gt(5))
 ```
 
-Helpful Arel builders can be found at https://github.com/matthuhiggins/arelastic/blob/master/lib/arelastic/builders/filter.rb.
-
 ### Querying ###
 
 To create a query string, pass a string to search.query:


### PR DESCRIPTION
The link to this file in the Arelastic gem is broken.

@matthuhiggins - is there a new place this link should point? I was uncertain looking at the Arelastic source in `lib/arelastic/builders/`.