### PR TITLE
Define method to get model name via index alias

### DIFF
--- a/lib/elastic_record/config.rb
+++ b/lib/elastic_record/config.rb
@@ -13,6 +13,10 @@ module ElasticRecord
         @models ||= model_names.map { |model_name| model_name.constantize }
       end
 
+      def class_for(index_alias)
+        models.find { |model| model.elastic_index.alias_name == index_alias }
+      end
+
       def servers
         @servers
       end

--- a/test/elastic_record/config_test.rb
+++ b/test/elastic_record/config_test.rb
@@ -11,6 +11,13 @@ class ElasticRecord::ConfigTest < MiniTest::Test
     assert_equal [Warehouse, Widget, WidgetQuery, Project], ElasticRecord::Config.models
   end
 
+  def test_class_for
+    ElasticRecord::Config.model_names = %w(Widget)
+
+    refute ElasticRecord::Config.class_for('not_an_index')
+    assert_equal Widget, ElasticRecord::Config.class_for('widgets')
+  end
+
   def test_servers
     with_servers ['abc.com', 'xyz.com'] do
       assert_equal ['abc.com', 'xyz.com'], ElasticRecord::Config.servers


### PR DESCRIPTION
See https://github.com/data-axle/content_system/pull/5254#discussion_r490365856

### Problem

We have no way of backtracking from index alias to model name.

### Solution

Provide a way.