### PR TITLE
Add rake task to create indexes idempotently

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,16 @@ Product.elastic_index.refresh            # Call the refresh API
 Product.elastic_index.get_mapping        # Get the index mapping defined by elastic search
 Product.elastic_index.update_mapping     # Update the elastic search mapping of the current index
 ```
+
+
+## Development
+
+```bash
+# Setup the database
+$ cp test/dummy/.env.example test/dummy/.env
+$ bundle exec rake app:db:setup
+$ bundle exec rake app:db:setup RAILS_ENV=test
+
+# Run tests
+$ bundle exec rake
+```

--- a/lib/elastic_record/tasks/index.rake
+++ b/lib/elastic_record/tasks/index.rake
@@ -32,6 +32,19 @@ namespace :index do
   desc "Recreate index for CLASS or all models."
   task reset: ['index:drop', 'index:create']
 
+  desc "Create index for all models that don't already have one"
+  task create_missing: :environment do
+    ElasticRecord::Task.get_models.each do |model|
+      index = model.elastic_index
+      if (all_names = index.all_names).empty?
+        index_name = index.create_and_deploy
+        puts "Created #{model.name} index (#{index_name})"
+      else
+        puts "#{model.name} already has an index (#{all_names.last})"
+      end
+    end
+  end
+
   task update_mapping: :environment do
     ElasticRecord::Task.get_models.each do |model|
       model.elastic_index.create_and_deploy


### PR DESCRIPTION
This change will allow content_system's `bin/setup` to be idempotent, as Rails intended for it to be.