### PR TITLE
Move scroll_id to a post request

### DIFF
--- a/lib/elastic_record/index/search.rb
+++ b/lib/elastic_record/index/search.rb
@@ -88,8 +88,8 @@ module ElasticRecord
       end
 
       def scroll(scroll_id, scroll_keep_alive)
-        options = {scroll_id: scroll_id, scroll: scroll_keep_alive}
-        connection.json_get("/_search/scroll?#{options.to_query}")
+        options = { scroll_id: scroll_id, scroll: scroll_keep_alive }
+        connection.json_post("/_search/scroll", options)
       rescue ElasticRecord::ConnectionError => e
         case e.status_code
         when '400' then raise ElasticRecord::InvalidScrollError, e.message


### PR DESCRIPTION
scroll_id can be large depending on shards.

Move to the body of a post request according to https://stackoverflow.com/questions/63587243/scroll-id-returned-by-scroll-api-is-too-long