### PR TITLE
Update ES version to more recent version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,7 +27,7 @@ jobs:
           POSTGRES_USER: runner
           POSTGRES_HOST_AUTH_METHOD: trust
       elasticsearch:
-        image: elasticsearch:7.6.0
+        image: elasticsearch:7.12.0
         options: >-
           --health-cmd "curl http://localhost:9200/_cluster/health"
           --health-interval 10s

--- a/test/elastic_record/log_subscriber_test.rb
+++ b/test/elastic_record/log_subscriber_test.rb
@@ -16,14 +16,13 @@ class ElasticRecord::LogSubscriberTest < ActiveSupport::TestCase
   # end
 
   def test_request_notification
-    stub_request(:any, '/test').to_return(status: 200, body: Oj.dump('the' => 'response'))
-    Widget.elastic_connection.json_get "/widgets", {'foo' => 'bar'}
+    Widget.elastic_connection.json_get "/widgets/_search", { query: { term: { color: "blue" } } }
 
     wait
 
     assert_equal 1, @logger.logged(:debug).size
-    assert_match /GET (.*)widgets/, @logger.logged(:debug)[0]
-    assert_match %r['#{Oj.dump('foo' => 'bar')}'], @logger.logged(:debug)[0]
+    assert_match /GET (.*)widgets\/_search/, @logger.logged(:debug)[0]
+    assert_match /'{\"query\":{\"term\":{\"color\":\"blue\"}}}'/, @logger.logged(:debug)[0]
   end
 
   def test_request_notification_escaping


### PR DESCRIPTION
In recent versions of ES API calls that don't take a body will error when passed a body.
See https://github.com/elastic/elasticsearch/issues/69532

Passing a search request allows a body.