### PR TITLE
Support parent-child joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ When one model inherits from another, ElasticRecord makes some assumptions about
 These can all be overridden.  For instance, it might be desirable for the child documents to be in a separate index.
 
 ### Join fields
-ElasticSearch provides support for join queries by providing a mechanism for declaring a join field that specifies the parent-child relationship between different types of records on the same index.
+ElasticSearch supports declaring a join field that specifies a parent-child relationship between documents of different types in the same index ([docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/parent-join.html)).
 ElasticRecord provides a short-(but not-so-short)-cut for declaring the mapping:
 
 ```ruby
@@ -222,16 +222,16 @@ end
 ```
 
 `has_es_children` accepts an optional `name` argument, with a sane default. In the above example, it would default to `country`. The name can later be used to construct `has_parent` queries.
-The `join_field` will be used as the name of a method that gets defined both on the parent and on all children (and grandchildren), in addition to being the name of the mapping for the join field.  Be sure this doesn't conflict with the name of an existing method.  You are unlikely to need to use this name directly.
+ElasticRecord will define a getter method with the same name as the value provided to `join_field` on both the parent and all children (and grandchildren).
 
-`::ElasticRecord::Model::Joining::JoinChild.new`, too, accepts optional arguments with sane defaults:
-* `name`: In the above example, it would default to `state`. The name can later be used to construct `has_child` queries.
-* `children`: Can be another instance of `::ElasticRecord::Model::Joining::JoinChild` or an Array of them. Defaults to an empty Array.  Theoretically, an arbitrary number of layers of parent-child joins can be achieved this way.
-* `parent_id_accessor`: A method to call on the child to retrieve the ID of the parent. Can be a proc, which will be executed in the context of the child object, or the name of a method to be called on the child object.  In the above example, it would default to `country_id`.
+`::ElasticRecord::Model::Joining::JoinChild.new` optional arguments:
+* `name`: defaults to the snake case version of the value provided to `klass` (e.g. `state` in the example above). Can be used to construct `has_child` queries.
+* `children`: Another instance of `::ElasticRecord::Model::Joining::JoinChild` or an Array of instances. Defaults to an empty Array.  Theoretically, an arbitrary number of layers of parent-child joins can be achieved this way.
+* `parent_id_accessor`: Determines how the ID of the parent is retrieved. Can be a proc, which will be executed in the context of the child object, or a symbol corresponding to the name of a method defined on the child object.  In the above example, it would default to `country_id`.
 
-Note: Creating, deleting and updating mapping on the index must be handled via the Top-Level parent.  Running `rake index:create CLASS=State` has no effect.
-
-Note: The `load_from_source` configuration is not currently supported for indexes with a join field, though theoretically it could be implemented.
+Notes:
+* Creating, deleting and updating mapping on the index must be handled via the Top-Level parent.  Running `rake index:create CLASS=State` has no effect.
+* The `load_from_source` configuration is not currently supported for indices with a join field.
 
 ### Load Documents from Source
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ ElasticRecord will define a getter method with the same name as the value provid
 * `name`: defaults to the snake case version of the value provided to `klass` (e.g. `state` in the example above). Can be used to construct `has_child` queries.
 * `children`: Another instance of `::ElasticRecord::Model::Joining::JoinChild` or an Array of instances. Defaults to an empty Array.  Theoretically, an arbitrary number of layers of parent-child joins can be achieved this way.
 * `parent_id_accessor`: Determines how the ID of the parent is retrieved. Can be a proc, which will be executed in the context of the child object, or a symbol corresponding to the name of a method defined on the child object.  In the above example, it would default to `country_id`.
-
+* `parent_accessor`: Determines how the parent is retrieved. Can be a proc, which will be executed in the context of the child object, or a symbol corresponding to the name of a method defined on the child object.  In the above example, it would default to `country`.  The is used to retrieve routing for multi-layered parent-child joins.
 Notes:
 * Creating, deleting and updating mapping on the index must be handled via the Top-Level parent.  Running `rake index:create CLASS=State` has no effect.
 * The `load_from_source` configuration is not currently supported for indices with a join field.

--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test}/*`.split("\n")
 
-  s.add_dependency 'arelastic', '>= 2.6.0'
+  s.add_dependency 'arelastic', '>= 3.3.0'
   s.add_dependency 'activemodel'
 end

--- a/lib/elastic_record.rb
+++ b/lib/elastic_record.rb
@@ -21,6 +21,7 @@ module ElasticRecord
     autoload :Callbacks
     autoload :ElasticConnection
     autoload :FromSearchHit
+    autoload :Joining
     autoload :Searching
   end
 

--- a/lib/elastic_record/index/manage.rb
+++ b/lib/elastic_record/index/manage.rb
@@ -1,6 +1,8 @@
 module ElasticRecord
   class Index
     module Manage
+      attr_accessor :disable_index_creation
+
       def create_and_deploy(index_name = new_index_name)
         create(index_name)
         deploy(index_name)
@@ -8,6 +10,8 @@ module ElasticRecord
       end
 
       def create(index_name = new_index_name, setting_overrides: {})
+        return if disable_index_creation
+
         mapping_params = {
           "mappings" => mapping,
           "settings" => settings.merge(setting_overrides)
@@ -18,10 +22,14 @@ module ElasticRecord
       end
 
       def delete(index_name)
+        return if disable_index_creation
+
         connection.json_delete index_name
       end
 
       def delete_all
+        return if disable_index_creation
+
         all_names.each do |index_name|
           delete index_name
         end
@@ -32,6 +40,8 @@ module ElasticRecord
       end
 
       def deploy(index_name)
+        return if disable_index_creation
+
         actions = [
           {
             add: {

--- a/lib/elastic_record/model.rb
+++ b/lib/elastic_record/model.rb
@@ -5,6 +5,7 @@ module ElasticRecord
     included do
       extend Searching
       extend FromSearchHit
+      extend Joining
       include ElasticConnection
       include Callbacks
       include AsDocument

--- a/lib/elastic_record/model/joining.rb
+++ b/lib/elastic_record/model/joining.rb
@@ -19,7 +19,7 @@ module ElasticRecord
             end
           end
 
-          name ||= klass.to_s.underscore
+          name ||= klass.to_s.demodulize.underscore
 
           children = Array.wrap(children)
           children.each do |child|
@@ -89,7 +89,7 @@ module ElasticRecord
           raise "Naming your join field '#{join_field}' will clobber an existing #{self} method with that name!  Choose a different name!"
         end
 
-        name ||= to_s.underscore
+        name ||= to_s.demodulize.underscore
         klass = self
         define_singleton_method(:es_root) { klass }
         define_singleton_method(:es_join_field) { join_field }

--- a/lib/elastic_record/model/joining.rb
+++ b/lib/elastic_record/model/joining.rb
@@ -1,0 +1,108 @@
+module ElasticRecord
+  module Model
+    module Joining
+      class JoinChild
+        attr_reader :klass, :name, :children, :parent_id_accessor
+
+        def initialize(klass:, name: nil, children: [], parent_id_accessor: nil)
+          unless klass < ElasticRecord::Model
+            raise "JoinChild#klass must be instances of `ElasticRecord::Model`. Cannot be #{klass}!"
+          end
+
+          if klass.instance_methods.include?(:es_join_name)
+            raise "Cannot initialize a #{self.class} with a klass that is already a parent!  Remove the call to has_es_children from #{klass}."
+          end
+
+          if parent_id_accessor
+            unless parent_id_accessor.respond_to?(:call) || (klass.instance_methods + klass.private_instance_methods).include?(parent_id_accessor.to_sym)
+              raise "parent_id_accessor must be callable for #{klass}"
+            end
+          end
+
+          name ||= klass.to_s.underscore
+
+          children = Array.wrap(children)
+          children.each do |child|
+            unless child.is_a?(self.class)
+              raise "JoinChild#children can only contain #{self.class}. Cannot be #{child}!"
+            end
+          end
+
+          @klass, @name, @children, @parent_id_accessor = klass, name, children, parent_id_accessor
+        end
+
+        def assign_to_parent!(parent:)
+          unless parent < ElasticRecord::Model
+            raise "Parent must be instances of `ElasticRecord::Model`. #{parent} cannot be parent!"
+          end
+
+          unless parent.respond_to?(:es_join_field)
+            raise "Don't call #{self.class}#assign_to_parent! directly!  It's for internal use only."
+          end
+
+          join_field = parent.es_join_field
+          if (klass.instance_methods + klass.private_instance_methods).include?(join_field.to_sym)
+            raise "Naming your join field '#{join_field}' on #{parent} will clobber an existing #{klass} method with that name!  Choose a different name!"
+          end
+
+          name = self.name
+          parent_id_accessor = self.parent_id_accessor
+
+          if parent_id_accessor.nil?
+            parent_id_accessor = "#{parent.es_join_name}_id"
+            unless (klass.instance_methods + klass.private_instance_methods).include?(parent_id_accessor.to_sym)
+              raise "#{klass} does not respond to #{parent_id_accessor}.  Please specify a parent_id_accessor for #{self.class}(klass: #{klass})!"
+            end
+          end
+          klass.define_singleton_method(:es_root) { parent.es_root }
+          klass.define_singleton_method(:es_join_field) { join_field }
+          klass.define_singleton_method(:es_join_name) { name }
+          klass.define_method(:es_join_name) { name }
+          klass.define_method(join_field) do
+            parent_id = parent_id_accessor.respond_to?(:call) ? instance_exec(&parent_id_accessor) : send(parent_id_accessor)
+            { 'name' => es_join_name.to_s, 'parent' => parent_id }
+          end
+          klass.define_method(:routing) do
+            if parent.respond_to?(:routing)
+              parent.routing
+            else
+              parent_id_accessor.respond_to?(:call) ? instance_exec(&parent_id_accessor) : send(parent_id_accessor)
+            end
+          end
+
+          klass.elastic_index.alias_name = parent.es_root.elastic_index.alias_name
+          klass.elastic_index.disable_index_creation = true
+          parent.es_root.elastic_index.mapping.merge!(klass.elastic_index.mapping)
+
+          children.each { |child| assign_to_parent!(parent: klass) }
+        end
+
+        def relations
+          children.map(&:relations).inject({ name => children.map(&:name) }, :merge)
+        end
+      end
+
+      def has_es_children(join_field:, name: nil, children:)
+        children = Array.wrap(children)
+
+        if (instance_methods + private_instance_methods).include?(join_field.to_sym)
+          raise "Naming your join field '#{join_field}' will clobber an existing #{self} method with that name!  Choose a different name!"
+        end
+
+        name ||= to_s.underscore
+        klass = self
+        define_singleton_method(:es_root) { klass }
+        define_singleton_method(:es_join_field) { join_field }
+        define_singleton_method(:es_join_name) { name }
+        define_method(:es_join_name) { name }
+        define_method(join_field) do
+          { 'name' => es_join_name.to_s }
+        end
+
+        children.each { |child| child.assign_to_parent!(parent: self)}
+        relations = children.map(&:relations).inject({ name => children.map(&:name) }, :merge).keep_if { |k, v| v.present? }
+        elastic_index.mapping[:properties][join_field] = { type: "join", relations: relations }
+      end
+    end
+  end
+end

--- a/lib/elastic_record/model/joining.rb
+++ b/lib/elastic_record/model/joining.rb
@@ -74,7 +74,7 @@ module ElasticRecord
           klass.elastic_index.disable_index_creation = true
           parent.es_root.elastic_index.mapping.merge!(klass.elastic_index.mapping)
 
-          children.each { |child| assign_to_parent!(parent: klass) }
+          children.each { |child| child.assign_to_parent!(parent: klass) }
         end
 
         def relations

--- a/lib/elastic_record/relation/hits.rb
+++ b/lib/elastic_record/relation/hits.rb
@@ -15,7 +15,13 @@ module ElasticRecord
         @search_results ||= begin
           options = { typed_keys: true, track_total_hits: true }
           options[:search_type] = search_type_value if search_type_value
-          options[:_source] = klass.elastic_index.load_from_source
+          options[:_source] = if klass.elastic_index.load_from_source
+            true
+          elsif klass.respond_to?(:es_join_field)
+            klass.es_join_field
+          else
+            false
+          end
 
           klass.elastic_index.search(as_elastic, options)
         end

--- a/test/elastic_record/integration/active_record_test.rb
+++ b/test/elastic_record/integration/active_record_test.rb
@@ -1,6 +1,11 @@
 require 'helper'
 
 class ElasticRecord::ActiveRecordTest < MiniTest::Test
+  def setup
+    super
+    Warehouse.destroy_all
+  end
+
   def test_ordering
     poo_product = Warehouse.create! name: "Poo"
     bear_product = Warehouse.create! name: "Bear"

--- a/test/elastic_record/model/joining_test.rb
+++ b/test/elastic_record/model/joining_test.rb
@@ -1,31 +1,31 @@
 require 'helper'
 
 class ElasticRecord::Model::JoiningTest < MiniTest::Test
-  class Child < ActiveRecord::Base
+  class Son < ActiveRecord::Base
     include ElasticRecord::Model
     self.elastic_index.mapping[:properties] = ::Widget.elastic_index.mapping[:properties].dup
     self.table_name = 'widgets'
-    belongs_to :parent, foreign_key: :warehouse_id
+    belongs_to :mother, foreign_key: :warehouse_id
   end
 
-  class Parent < ActiveRecord::Base
+  class Mother < ActiveRecord::Base
     include ElasticRecord::Model
     self.elastic_index.mapping[:properties] = ::Warehouse.elastic_index.mapping[:properties].dup
     self.table_name = 'warehouses'
-    child = ::ElasticRecord::Model::Joining::JoinChild.new(klass: Child, name: 'son', parent_id_accessor: ->{ warehouse_id })
-    has_es_children(join_field: 'arbitrary', name: 'mom', children: child)
+    son = ::ElasticRecord::Model::Joining::JoinChild.new(klass: Son, parent_id_accessor: ->{ warehouse_id })
+    has_es_children(join_field: 'arbitrary', children: son)
     elastic_index.reset
   end
 
   def setup
     super
-    Parent.destroy_all
-    Child.destroy_all
+    Mother.destroy_all
+    Son.destroy_all
   end
 
   def test_elastic_index_model
-    assert_equal Parent, Parent.elastic_index.model
-    assert_equal Child, Child.elastic_index.model
+    assert_equal Mother, Mother.elastic_index.model
+    assert_equal Son, Son.elastic_index.model
   end
 
   def test_elastic_index_mapping
@@ -33,7 +33,7 @@ class ElasticRecord::Model::JoiningTest < MiniTest::Test
       "arbitrary" => {
         "type" => "join",
         "eager_global_ordinals" => true,
-        "relations" => { "mom" => "son" }
+        "relations" => { "mother" => "son" }
       },
       "color" => { "type" => "keyword" },
       "name" => {
@@ -52,37 +52,37 @@ class ElasticRecord::Model::JoiningTest < MiniTest::Test
         }
       }
     }
-    assert_equal expected_mapping, Parent.elastic_index.get_mapping.fetch('properties')
-    assert_equal expected_mapping, Child.elastic_index.get_mapping.fetch('properties')
+    assert_equal expected_mapping, Mother.elastic_index.get_mapping.fetch('properties')
+    assert_equal expected_mapping, Son.elastic_index.get_mapping.fetch('properties')
   end
 
   def test_elastic_index_creation
-    refute Parent.elastic_index.disable_index_creation
-    assert Child.elastic_index.disable_index_creation
+    refute Mother.elastic_index.disable_index_creation
+    assert Son.elastic_index.disable_index_creation
   end
 
   def test_index_to_elasticsearch
-    parent = Parent.new(id: 9, name: 'Queen Victoria')
-    Parent.insert_all([parent.attributes])
-    parent.index_to_elasticsearch
+    mother = Mother.new(id: 9, name: 'Queen Victoria')
+    Mother.insert_all([mother.attributes])
+    mother.index_to_elasticsearch
 
-    child = Child.new(id: 10, name: 'King Edward VII', color: 'green', price: 50, parent: parent)
-    Child.insert_all([child.attributes])
-    child.index_to_elasticsearch
+    son = Son.new(id: 10, name: 'King Edward VII', color: 'green', price: 50, mother: mother)
+    Son.insert_all([son.attributes])
+    son.index_to_elasticsearch
 
-    Parent.elastic_index.refresh
+    Mother.elastic_index.refresh
 
-    assert_equal [parent.name], Parent.filter(Parent.arelastic.queries.term('arbitrary', 'mom')).to_a.map(&:name)
-    assert_equal [child.name], Child.filter(Child.arelastic.queries.term('arbitrary', 'son')).to_a.map(&:name)
-    assert_equal [], Parent.filter(Parent.arelastic.queries.term('arbitrary', 'son')).to_a
-    assert_equal [], Child.filter(Child.arelastic.queries.term('arbitrary', 'mom')).to_a
+    assert_equal [mother.name], Mother.filter(Mother.arelastic.queries.term('arbitrary', 'mother')).to_a.map(&:name)
+    assert_equal [son.name], Son.filter(Son.arelastic.queries.term('arbitrary', 'son')).to_a.map(&:name)
+    assert_equal [], Mother.filter(Mother.arelastic.queries.term('arbitrary', 'son')).to_a
+    assert_equal [], Son.filter(Son.arelastic.queries.term('arbitrary', 'mother')).to_a
 
-    assert_equal [parent.name], Parent.filter(Parent.arelastic.queries.match_all.has_child('son')).to_a.map(&:name)
-    assert_equal [], Parent.filter(Parent.arelastic.queries.match_all.has_parent('mom')).to_a.map(&:name)
-    assert_equal [child.name], Child.filter(Child.arelastic.queries.match_all.has_parent('mom')).to_a.map(&:name)
-    assert_equal [], Child.filter(Child.arelastic.queries.match_all.has_child('son')).to_a.map(&:name)
+    assert_equal [mother.name], Mother.filter(Mother.arelastic.queries.match_all.has_child('son')).to_a.map(&:name)
+    assert_equal [], Mother.filter(Mother.arelastic.queries.match_all.has_parent('mother')).to_a.map(&:name)
+    assert_equal [son.name], Son.filter(Son.arelastic.queries.match_all.has_parent('mother')).to_a.map(&:name)
+    assert_equal [], Son.filter(Son.arelastic.queries.match_all.has_child('son')).to_a.map(&:name)
 
-    assert_equal [parent.name], Parent.filter(Parent.arelastic.queries.match_all).to_a.map(&:name)
-    assert_equal [child.name], Child.filter(Child.arelastic.queries.match_all).to_a.map(&:name)
+    assert_equal [mother.name], Mother.filter(Mother.arelastic.queries.match_all).to_a.map(&:name)
+    assert_equal [son.name], Son.filter(Son.arelastic.queries.match_all).to_a.map(&:name)
   end
 end

--- a/test/elastic_record/model/joining_test.rb
+++ b/test/elastic_record/model/joining_test.rb
@@ -1,0 +1,88 @@
+require 'helper'
+
+class ElasticRecord::Model::JoiningTest < MiniTest::Test
+  class Child < ActiveRecord::Base
+    include ElasticRecord::Model
+    self.elastic_index.mapping[:properties] = ::Widget.elastic_index.mapping[:properties].dup
+    self.table_name = 'widgets'
+    belongs_to :parent, foreign_key: :warehouse_id
+  end
+
+  class Parent < ActiveRecord::Base
+    include ElasticRecord::Model
+    self.elastic_index.mapping[:properties] = ::Warehouse.elastic_index.mapping[:properties].dup
+    self.table_name = 'warehouses'
+    child = ::ElasticRecord::Model::Joining::JoinChild.new(klass: Child, name: 'son', parent_id_accessor: ->{ warehouse_id })
+    has_es_children(join_field: 'arbitrary', name: 'mom', children: child)
+    elastic_index.reset
+  end
+
+  def setup
+    super
+    Parent.destroy_all
+    Child.destroy_all
+  end
+
+  def test_elastic_index_model
+    assert_equal Parent, Parent.elastic_index.model
+    assert_equal Child, Child.elastic_index.model
+  end
+
+  def test_elastic_index_mapping
+    expected_mapping = {
+      "arbitrary" => {
+        "type" => "join",
+        "eager_global_ordinals" => true,
+        "relations" => { "mom" => "son" }
+      },
+      "color" => { "type" => "keyword" },
+      "name" => {
+        "type" => "text",
+        "fields" => {
+          "raw" => { "type" => "keyword" }
+        }
+      },
+      "price" => {
+        "type" => "long"
+      },
+      "warehouse_id" => { "type" => "keyword" },
+      "widget_part" => {
+        "properties" => {
+          "name" => { "type" => "keyword" }
+        }
+      }
+    }
+    assert_equal expected_mapping, Parent.elastic_index.get_mapping.fetch('properties')
+    assert_equal expected_mapping, Child.elastic_index.get_mapping.fetch('properties')
+  end
+
+  def test_elastic_index_creation
+    refute Parent.elastic_index.disable_index_creation
+    assert Child.elastic_index.disable_index_creation
+  end
+
+  def test_index_to_elasticsearch
+    parent = Parent.new(id: 9, name: 'Queen Victoria')
+    Parent.insert_all([parent.attributes])
+    parent.index_to_elasticsearch
+
+    child = Child.new(id: 10, name: 'King Edward VII', color: 'green', price: 50, parent: parent)
+    Child.insert_all([child.attributes])
+    child.index_to_elasticsearch
+
+    Parent.elastic_index.refresh
+
+    assert_equal [parent.name], Parent.filter(Parent.arelastic.queries.term('arbitrary', 'mom')).to_a.map(&:name)
+    assert_equal [child.name], Child.filter(Child.arelastic.queries.term('arbitrary', 'son')).to_a.map(&:name)
+    assert_equal [], Parent.filter(Parent.arelastic.queries.term('arbitrary', 'son')).to_a
+    assert_equal [], Child.filter(Child.arelastic.queries.term('arbitrary', 'mom')).to_a
+
+    assert_equal [parent.name], Parent.filter(Parent.arelastic.queries.match_all.has_child('son')).to_a.map(&:name)
+    assert_equal [], Parent.filter(Parent.arelastic.queries.match_all.has_parent('mom')).to_a.map(&:name)
+    assert_equal [child.name], Child.filter(Child.arelastic.queries.match_all.has_parent('mom')).to_a.map(&:name)
+    assert_equal [], Child.filter(Child.arelastic.queries.match_all.has_child('son')).to_a.map(&:name)
+
+    assert_equal [parent.name], Parent.filter(Parent.arelastic.queries.match_all).to_a.map(&:name)
+    assert_equal [child.name], Child.filter(Child.arelastic.queries.match_all).to_a.map(&:name)
+  end
+end

--- a/test/elastic_record/relation/batches_test.rb
+++ b/test/elastic_record/relation/batches_test.rb
@@ -3,6 +3,7 @@ require 'helper'
 class ElasticRecord::Relation::BatchesTest < MiniTest::Test
   def setup
     super
+    Widget.destroy_all
     @red_widget   = Widget.create!(color: 'red')
     @blue_widget  = Widget.create!(color: 'blue')
     @green_widget = Widget.create!(color: 'green')

--- a/test/elastic_record/searching_test.rb
+++ b/test/elastic_record/searching_test.rb
@@ -9,7 +9,7 @@ class ElasticRecord::SearchingTest < MiniTest::Test
   end
 
   def test_elastic_search
-    widget = Widget.create(color: 'red')
+    widget = Widget.create!(color: 'red')
     assert_equal widget, Widget.elastic_search.filter(color: 'red').first
     assert_equal widget, Widget.es.filter(color: 'red').first
   end
@@ -23,6 +23,7 @@ class ElasticRecord::SearchingTest < MiniTest::Test
   end
 
   def test_elastic_scope
+    ScopedWidget.create!(color: :blue)
     relation = ScopedWidget.by_color('blue')
 
     assert_equal ScopedWidget.elastic_relation.filter(color: 'blue'), relation


### PR DESCRIPTION
[INFO-9454](https://infogroup.atlassian.net/browse/INFO-9454)

[ElasticSearch Reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/parent-join.html)

Note that this depends on [the latest arelastic PR](https://github.com/matthuhiggins/arelastic/pull/33).  I have requested a new release from the maintainer after which I will update the gemspec here to require the latest version.

@matthinea I was able to preserve your commit that renamed `parent` => `routing` without making any changes to that file.