### PR TITLE
Bump required version of arelastic

### DIFF
--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test}/*`.split("\n")
 
-  s.add_dependency 'arelastic', '>= 3.3.1'
+  s.add_dependency 'arelastic', '>= 3.3.2'
   s.add_dependency 'activemodel'
 end


### PR DESCRIPTION
No real changes, just getting the latest version Arelastic has on RubyGems and in its gemspec