### PR TITLE
Support simpler `has_es_children` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,19 @@ class State
   include ElasticRecord::Model
 end
 
+class City
+  include ElasticRecord::Model
+end
+
 class Country
   include ElasticRecord::Model
 
   has_es_children(
-    children:   State,
-    join_field: 'pick_a_name_for_the_join_field'
+    join_field: 'pick_a_name_for_the_join_field',
+    children:   [
+      State,
+      ElasticRecord::Model::Joining::JoinChild.new(klass: City, parent_id_accessor: :country_code)
+    ]
   )
 end
 ```

--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ class Country
   include ElasticRecord::Model
 
   has_es_children(
-    join_field: 'pick_a_name_for_the_join_field',
-    children: ::ElasticRecord::Model::Joining::JoinChild.new(klass: State)
+    children:   State,
+    join_field: 'pick_a_name_for_the_join_field'
   )
 end
 ```
@@ -224,7 +224,9 @@ end
 `has_es_children` accepts an optional `name` argument, with a sane default. In the above example, it would default to `country`. The name can later be used to construct `has_parent` queries.
 ElasticRecord will define a getter method with the same name as the value provided to `join_field` on both the parent and all children (and grandchildren).
 
-`::ElasticRecord::Model::Joining::JoinChild.new` optional arguments:
+The `children` argument expects a Class, Array of Classes, or, for complex nestings, an instance of `::ElasticRecord::Model::Joining::JoinChild.new`.
+
+`::ElasticRecord::Model::Joining::JoinChild.new` accepts additional, optional arguments:
 * `name`: defaults to the snake case version of the value provided to `klass` (e.g. `state` in the example above). Can be used to construct `has_child` queries.
 * `children`: Another instance of `::ElasticRecord::Model::Joining::JoinChild` or an Array of instances. Defaults to an empty Array.  Theoretically, an arbitrary number of layers of parent-child joins can be achieved this way.
 * `parent_id_accessor`: Determines how the ID of the parent is retrieved. Can be a proc, which will be executed in the context of the child object, or a symbol corresponding to the name of a method defined on the child object.  In the above example, it would default to `country_id`.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ end
 `has_es_children` accepts an optional `name` argument, with a sane default. In the above example, it would default to `country`. The name can later be used to construct `has_parent` queries.
 ElasticRecord will define a getter method with the same name as the value provided to `join_field` on both the parent and all children (and grandchildren).
 
-The `children` argument expects a Class, Array of Classes, or, for complex nestings, an instance of `::ElasticRecord::Model::Joining::JoinChild.new`.
+The `children` argument expects a Class or, for complex nestings, an instance of `::ElasticRecord::Model::Joining::JoinChild.new`.  You can also pass an Array, each element of which is either a `Class` or a `::ElasticRecord::Model::Joining::JoinChild.new`.
 
 `::ElasticRecord::Model::Joining::JoinChild.new` accepts additional, optional arguments:
 * `name`: defaults to the snake case version of the value provided to `klass` (e.g. `state` in the example above). Can be used to construct `has_child` queries.

--- a/lib/elastic_record/model/joining.rb
+++ b/lib/elastic_record/model/joining.rb
@@ -133,7 +133,7 @@ module ElasticRecord
 
         relations = join_children.map(&:relations).inject({ name => join_children.map(&:name) }, :merge).keep_if { |k, v| v.present? }
         elastic_index.mapping[:properties][join_field] = { type: "join", relations: relations }
-        children.each { |child| child.assign_to_parent!(parent: self)}
+        join_children.each { |child| child.assign_to_parent!(parent: self)}
       end
     end
   end

--- a/lib/elastic_record/model/joining.rb
+++ b/lib/elastic_record/model/joining.rb
@@ -5,13 +5,8 @@ module ElasticRecord
         attr_reader :klass, :name, :children, :parent_id_accessor
 
         def self.build_children(user_input)
-          case user_input
-          when Class, Array
-            Array.wrap(user_input).map { |child| new(klass: child) }
-          when ElasticRecord::Model::Joining::JoinChild
-            Array.wrap(user_input)
-          else
-            raise "Expected a Class, Array, or ElasticRecord::Model::Joining::JoinChild instance as first arg to has_es_children. Received #{user_input} instead."
+          Array.wrap(user_input).map do |join_child|
+            join_child.is_a?(self) ? join_child : new(klass: join_child)
           end
         end
 


### PR DESCRIPTION
### Problem

The interface to `has_es_children` is a little cumbersome. Most users won't require complex nestings and will only want to specify a single child or two.

### Solution

Support passing an instance of `Class` as the `children` argument to `has_es_children`. `README` has examples.