### PR TITLE
`class_for` shouldn't return an index whose creation has been disabled

### DIFF
--- a/lib/elastic_record/config.rb
+++ b/lib/elastic_record/config.rb
@@ -14,7 +14,9 @@ module ElasticRecord
       end
 
       def class_for(index_alias)
-        models.find { |model| model.elastic_index.alias_name == index_alias }
+        models.find do |model|
+          !model.elastic_index.disable_index_creation && model.elastic_index.alias_name == index_alias
+        end
       end
 
       def servers

--- a/test/elastic_record/config_test.rb
+++ b/test/elastic_record/config_test.rb
@@ -16,6 +16,9 @@ class ElasticRecord::ConfigTest < MiniTest::Test
 
     refute ElasticRecord::Config.class_for('not_an_index')
     assert_equal Widget, ElasticRecord::Config.class_for('widgets')
+
+    Widget.elastic_index.disable_index_creation = true
+    refute ElasticRecord::Config.class_for('widgets')
   end
 
   def test_servers


### PR DESCRIPTION
### Problem

```ruby
ElasticRecord::Config.class_for('places')
=> ChildContact
```

### Solution

`class_for` can't return indices whose creation has been disabled.