### PR TITLE
Filter by join type

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,11 @@ end
 `has_es_children` accepts an optional `name` argument, with a sane default. In the above example, it would default to `country`. The name can later be used to construct `has_parent` queries.
 ElasticRecord will define a getter method with the same name as the value provided to `join_field` on both the parent and all children (and grandchildren).
 
-The `children` argument expects a Class, a Hash (with names as keys and classes as values), an instance of `::ElasticRecord::Model::Joining::JoinChild.new` (when you need to override any of the options below besides `name`), or an Array containing any combination thereof.
+The `children` argument can be:
+* a `Class` that includes `ElasticRecord::Model`
+* a `Hash` (with names as keys and classes as values)
+* an instance of `::ElasticRecord::Model::Joining::JoinChild.new` (when you need to override any of the options below besides `name`)
+* or an Array containing any combination thereof.
 
 `::ElasticRecord::Model::Joining::JoinChild.new` accepts additional, optional arguments:
 * `name`: defaults to the snake case version of the value provided to `klass` (e.g. `state` in the example above). Can be used to construct `has_child` queries.
@@ -244,7 +248,7 @@ The `children` argument expects a Class, a Hash (with names as keys and classes 
 * `parent_id_accessor`: Determines how the ID of the parent is retrieved. Can be a proc, which will be executed in the context of the child object, or a symbol corresponding to the name of a method defined on the child object.  In the above example, it would default to `country_id`.
 * `parent_accessor`: Determines how the parent is retrieved. Can be a proc, which will be executed in the context of the child object, or a symbol corresponding to the name of a method defined on the child object.  In the above example, it would default to `country`.  The is used to retrieve routing for multi-layered parent-child joins.
 
-**Note**: Creating, deleting and updating mapping on the index must be handled via the Top-Level parent.  Running `rake index:create CLASS=State` has no effect.
+**Note**: Creating, deleting and updating mapping on the index must be handled via the Top-Level parent.  In the above example, running `rake index:create CLASS=State` would have no effect.
 
 ### Load Documents from Source
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ class City
   include ElasticRecord::Model
 end
 
+class PostalCode
+  include ElasticRecord::Model
+end
+
 class Country
   include ElasticRecord::Model
 
@@ -222,6 +226,7 @@ class Country
     join_field: 'pick_a_name_for_the_join_field',
     children:   [
       State,
+      { zip: PostalCode },
       ElasticRecord::Model::Joining::JoinChild.new(klass: City, parent_id_accessor: :country_code)
     ]
   )
@@ -231,7 +236,7 @@ end
 `has_es_children` accepts an optional `name` argument, with a sane default. In the above example, it would default to `country`. The name can later be used to construct `has_parent` queries.
 ElasticRecord will define a getter method with the same name as the value provided to `join_field` on both the parent and all children (and grandchildren).
 
-The `children` argument expects a Class or, for complex nestings, an instance of `::ElasticRecord::Model::Joining::JoinChild.new`.  You can also pass an Array, each element of which is either a `Class` or a `::ElasticRecord::Model::Joining::JoinChild.new`.
+The `children` argument expects a Class, a Hash (with names as keys and classes as values), an instance of `::ElasticRecord::Model::Joining::JoinChild.new` (when you need to override any of the options below besides `name`), or an Array containing any combination thereof.
 
 `::ElasticRecord::Model::Joining::JoinChild.new` accepts additional, optional arguments:
 * `name`: defaults to the snake case version of the value provided to `klass` (e.g. `state` in the example above). Can be used to construct `has_child` queries.

--- a/README.md
+++ b/README.md
@@ -238,9 +238,8 @@ The `children` argument expects a Class or, for complex nestings, an instance of
 * `children`: Another instance of `::ElasticRecord::Model::Joining::JoinChild` or an Array of instances. Defaults to an empty Array.  Theoretically, an arbitrary number of layers of parent-child joins can be achieved this way.
 * `parent_id_accessor`: Determines how the ID of the parent is retrieved. Can be a proc, which will be executed in the context of the child object, or a symbol corresponding to the name of a method defined on the child object.  In the above example, it would default to `country_id`.
 * `parent_accessor`: Determines how the parent is retrieved. Can be a proc, which will be executed in the context of the child object, or a symbol corresponding to the name of a method defined on the child object.  In the above example, it would default to `country`.  The is used to retrieve routing for multi-layered parent-child joins.
-Notes:
-* Creating, deleting and updating mapping on the index must be handled via the Top-Level parent.  Running `rake index:create CLASS=State` has no effect.
-* The `load_from_source` configuration is not currently supported for indices with a join field.
+
+**Note**: Creating, deleting and updating mapping on the index must be handled via the Top-Level parent.  Running `rake index:create CLASS=State` has no effect.
 
 ### Load Documents from Source
 

--- a/lib/elastic_record/model/joining.rb
+++ b/lib/elastic_record/model/joining.rb
@@ -6,8 +6,15 @@ module ElasticRecord
 
         def self.build_children(user_input)
           Array.wrap(user_input).map do |join_child|
-            join_child.is_a?(self) ? join_child : new(klass: join_child)
-          end
+            case join_child
+            when Hash
+              join_child.map { |name, klass| new(name: name, klass: klass) }
+            when self
+              join_child
+            else
+              new(klass: join_child)
+            end
+          end.tap(&:flatten!)
         end
 
         def initialize(klass:, name: nil, children: [], parent_id_accessor: nil, parent_accessor: nil)

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -53,9 +53,6 @@ module ElasticRecord
 
     def find_hits(search_hits)
       if klass.elastic_index.load_from_source
-        if klass.respond_to?(:es_join_field)
-          raise "Loading parent/child joins from source is not currently supported!"
-        end
         search_hits.hits.map { |hit| klass.from_search_hit(hit) }
       else
         klass.find search_hits.to_ids

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -17,6 +17,7 @@ module ElasticRecord
     def initialize(klass, values: {})
       @klass = klass
       @values = values
+      super
     end
 
     def initialize_copy(other)
@@ -56,9 +57,6 @@ module ElasticRecord
           raise "Loading parent/child joins from source is not currently supported!"
         end
         search_hits.hits.map { |hit| klass.from_search_hit(hit) }
-      elsif klass.respond_to?(:es_join_field)
-        ids = search_hits.hits.filter_map { |hit| hit['_id'] if hit.dig('_source', klass.es_join_field, 'name') == klass.es_join_name }
-        klass.find(ids)
       else
         klass.find search_hits.to_ids
       end

--- a/lib/elastic_record/relation/hits.rb
+++ b/lib/elastic_record/relation/hits.rb
@@ -15,13 +15,7 @@ module ElasticRecord
         @search_results ||= begin
           options = { typed_keys: true, track_total_hits: true }
           options[:search_type] = search_type_value if search_type_value
-          options[:_source] = if klass.elastic_index.load_from_source
-            true
-          elsif klass.respond_to?(:es_join_field)
-            klass.es_join_field
-          else
-            false
-          end
+          options[:_source] = klass.elastic_index.load_from_source
 
           klass.elastic_index.search(as_elastic, options)
         end

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -38,6 +38,12 @@ module ElasticRecord
         end
       end
 
+      def initialize(*)
+        if klass.respond_to?(:es_join_field)
+          filter!(klass.es_join_field => klass.es_join_name)
+        end
+      end
+
       Relation::SINGLE_VALUE_METHODS.each do |name|
         define_method "#{name}_value" do
           @values[name]


### PR DESCRIPTION
Until now, when querying indices that contain parent-child joins,
we were retriving records of multiple types and then filtering
down to the type we were interesteed in on the client-side after
retrieving results.

This was inefficient.  Going forward, we will filter server-side.