### PR TITLE
Add ability to safe load relation records

### DIFF
--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -67,7 +67,7 @@ module ElasticRecord
         if safe?
           klass.where(id: ids).to_a
         else
-          klass.find search_hits.to_ids
+          klass.find ids
         end
       end
     end

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -51,16 +51,20 @@ module ElasticRecord
       @records ||= find_hits(search_hits)
     end
 
-    def load_safe_hits
-      @records ||= find_hits(search_hits, safe: true)
+    def safe!
+      @safe = true
     end
 
-    def find_hits(search_hits, safe: false)
+    def safe?
+      @safe
+    end
+
+    def find_hits(search_hits)
       if klass.elastic_index.load_from_source
         search_hits.hits.map { |hit| klass.from_search_hit(hit) }
       else
         ids = search_hits.to_ids
-        if safe
+        if safe?
           klass.where(id: ids).to_a
         else
           klass.find search_hits.to_ids

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -51,11 +51,20 @@ module ElasticRecord
       @records ||= find_hits(search_hits)
     end
 
-    def find_hits(search_hits)
+    def load_safe_hits
+      @records ||= find_hits(search_hits, safe: true)
+    end
+
+    def find_hits(search_hits, safe: false)
       if klass.elastic_index.load_from_source
         search_hits.hits.map { |hit| klass.from_search_hit(hit) }
       else
-        klass.find search_hits.to_ids
+        ids = search_hits.to_ids
+        if safe
+          klass.where(id: ids).to_a
+        else
+          klass.find search_hits.to_ids
+        end
       end
     end
 

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -51,6 +51,21 @@ class ElasticRecord::RelationTest < MiniTest::Test
     assert array.first.is_a?(Widget)
   end
 
+  def test_load_safe_hits
+    Widget.create!(color: 'red')
+    Widget.elastic_index.index_record(Widget.new(color: 'blue'))
+
+    relation = Widget.elastic_relation
+    assert_raises ActiveRecord::RecordNotFound do
+      relation.to_a
+    end
+    relation.load_safe_hits
+    array = relation.to_a
+
+    assert_equal 1, array.size
+    assert array.first.is_a?(Widget)
+  end
+
   def test_to_a_from_source
     warehouses = [Project.new(name: 'Latte'), Project.new(name: 'Americano')]
     Project.elastic_index.bulk_add(warehouses)

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -63,7 +63,7 @@ class ElasticRecord::RelationTest < MiniTest::Test
     array = relation.to_a
 
     assert_equal 1, array.size
-    assert array.first.is_a?(Widget)
+    assert_equal 'red', array.first.color
   end
 
   def test_to_a_from_source

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -51,7 +51,7 @@ class ElasticRecord::RelationTest < MiniTest::Test
     assert array.first.is_a?(Widget)
   end
 
-  def test_load_safe_hits
+  def test_safe_load
     Widget.create!(color: 'red')
     Widget.elastic_index.index_record(Widget.new(color: 'blue'))
 
@@ -59,9 +59,10 @@ class ElasticRecord::RelationTest < MiniTest::Test
     assert_raises ActiveRecord::RecordNotFound do
       relation.to_a
     end
-    relation.load_safe_hits
+    relation.safe!
     array = relation.to_a
 
+    assert relation.safe?
     assert_equal 1, array.size
     assert_equal 'red', array.first.color
   end


### PR DESCRIPTION
[JIRA](https://infogroup.atlassian.net/browse/INFO-9864)

**Problem:**

When ElasticRecord::Relation loads results #find_hits is called, which takes the IDs from ElasticSearch and calls `Model.find`. This results in an `ActiveRecord::RecordNotFound` error if Elastic has IDs that do not exist in Postgres.

**Solution:**

Add the ability to load the Relation's records without erroring on missing IDs. We could make this the default behavior for `find_hits`, but I'm concerned that will have larger repercussions (result order tests fail when defaulting to where instead of find), so initially this can be enabled where needed (I.E. for submissions).
