### PR TITLE
Filter queries by join type without changing the state of the object

### DIFF
--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -17,7 +17,6 @@ module ElasticRecord
     def initialize(klass, values: {})
       @klass = klass
       @values = values
-      super
     end
 
     def initialize_copy(other)

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -38,12 +38,6 @@ module ElasticRecord
         end
       end
 
-      def initialize(*)
-        if klass.respond_to?(:es_join_field)
-          filter!(klass.es_join_field => klass.es_join_name)
-        end
-      end
-
       Relation::SINGLE_VALUE_METHODS.each do |name|
         define_method "#{name}_value" do
           @values[name]
@@ -232,7 +226,13 @@ module ElasticRecord
         end
 
         def build_filter_nodes(filters)
-          filters.each_with_object([]) do |filter, nodes|
+          nodes = []
+
+          if klass.respond_to?(:es_join_field)
+            nodes << arelastic[klass.es_join_field].term(klass.es_join_name)
+          end
+
+          filters.each_with_object(nodes) do |filter, nodes|
             if filter.is_a?(Arelastic::Nodes::Node)
               nodes << filter
             elsif filter.is_a?(ElasticRecord::Relation)


### PR DESCRIPTION
By appending the join-type query to filter_values, we were getting mutually exclusive terms.