### PR TITLE
Fix nested & negated queries for models with joins

### DIFF
--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -19,7 +19,7 @@ module ElasticRecord
         end
 
         def add_filter_nodes_to_scope(filters)
-          filter_value = @scope.send(:build_filter_nodes, filters).map do |filter_node|
+          filter_value = @scope.send(:build_filter_nodes, filters, false).map do |filter_node|
             yield filter_node
           end
 
@@ -225,10 +225,10 @@ module ElasticRecord
           end
         end
 
-        def build_filter_nodes(filters)
+        def build_filter_nodes(filters, add_join_field_filter = true)
           nodes = []
 
-          if klass.respond_to?(:es_join_field)
+          if klass.respond_to?(:es_join_field) && add_join_field_filter
             nodes << arelastic[klass.es_join_field].term(klass.es_join_name)
           end
 

--- a/test/dummy/app/models/mother.rb
+++ b/test/dummy/app/models/mother.rb
@@ -1,0 +1,11 @@
+class Mother < ActiveRecord::Base
+  include ElasticRecord::Model
+
+  self.elastic_index.mapping[:properties] = ::Warehouse.elastic_index.mapping[:properties].dup
+  self.table_name = 'warehouses'
+
+  son = ::ElasticRecord::Model::Joining::JoinChild.new(klass: Son, parent_id_accessor: ->{ warehouse_id })
+  has_es_children(join_field: 'arbitrary', children: son)
+
+  elastic_index.reset
+end

--- a/test/dummy/app/models/son.rb
+++ b/test/dummy/app/models/son.rb
@@ -1,0 +1,9 @@
+class Son < ActiveRecord::Base
+  include ElasticRecord::Model
+
+  self.elastic_index.mapping[:properties] = ::Widget.elastic_index.mapping[:properties].dup
+
+  self.table_name = 'widgets'
+
+  belongs_to :mother, foreign_key: :warehouse_id
+end

--- a/test/elastic_record/model/joining_test.rb
+++ b/test/elastic_record/model/joining_test.rb
@@ -1,22 +1,6 @@
 require 'helper'
 
 class ElasticRecord::Model::JoiningTest < MiniTest::Test
-  class Son < ActiveRecord::Base
-    include ElasticRecord::Model
-    self.elastic_index.mapping[:properties] = ::Widget.elastic_index.mapping[:properties].dup
-    self.table_name = 'widgets'
-    belongs_to :mother, foreign_key: :warehouse_id
-  end
-
-  class Mother < ActiveRecord::Base
-    include ElasticRecord::Model
-    self.elastic_index.mapping[:properties] = ::Warehouse.elastic_index.mapping[:properties].dup
-    self.table_name = 'warehouses'
-    son = ::ElasticRecord::Model::Joining::JoinChild.new(klass: Son, parent_id_accessor: ->{ warehouse_id })
-    has_es_children(join_field: 'arbitrary', children: son)
-    elastic_index.reset
-  end
-
   def setup
     super
     Mother.elastic_index.enable_deferring!


### PR DESCRIPTION
### Problem

We're filtering by join field in `build_filter_nodes`. But calls to that method from `not` and `nested` result in negated and nested versions of that query, respectively.

### Solution

Don't add that field when negating. It'll still get added by the initial call to `filter`, as the tests show.