### PR TITLE
Include Request payload in error message for ConnectionErrors

### DIFF
--- a/lib/elastic_record/connection.rb
+++ b/lib/elastic_record/connection.rb
@@ -37,12 +37,12 @@ module ElasticRecord
       json_request :delete, path, json
     end
 
-    def json_request(method, path, json)
-      body = json.is_a?(Hash) ? JSON.generate(json) : json
+    def json_request(method, path, payload)
+      body = payload.is_a?(Hash) ? JSON.generate(payload) : payload
       response = http_request_with_retry(method, path, body)
 
       json = JSON.parse(response.body)
-      raise ConnectionError.new(response.code, json['error']) if json['error']
+      raise ConnectionError.new(response.code, json['error'], body) if json['error']
 
       json
     end

--- a/lib/elastic_record/errors.rb
+++ b/lib/elastic_record/errors.rb
@@ -3,9 +3,10 @@ module ElasticRecord
   end
 
   class ConnectionError < Error
-    attr_reader :status_code
-    def initialize(status_code, message)
+    attr_reader :status_code, :payload
+    def initialize(status_code, message, payload = nil)
       @status_code = status_code
+      message = "#{message} (for payload '#{payload}')" if payload
       super(message)
     end
   end


### PR DESCRIPTION
This will make it easier to debug when a ConnectionError occurs.  Most often, these errors occur because of an invalid request being sent to the server.

[Example HB](https://app.honeybadger.io/projects/1671/faults/53816528)