### PR TITLE
Define es_root everywhere

### DIFF
--- a/lib/elastic_record/model.rb
+++ b/lib/elastic_record/model.rb
@@ -35,6 +35,10 @@ module ElasticRecord
       def elastic_index=(index)
         @elastic_index = index
       end
+
+      def es_root
+        self
+      end
     end
 
     def index_to_elasticsearch

--- a/lib/elastic_record/model/joining.rb
+++ b/lib/elastic_record/model/joining.rb
@@ -84,7 +84,7 @@ module ElasticRecord
               raise "#{klass} does not respond to #{parent_id_accessor}.  Please specify a parent_id_accessor for #{self.class}(klass: #{klass})!"
             end
           end
-          klass.define_singleton_method(:es_root) { parent.es_root }
+          klass.redefine_singleton_method(:es_root) { parent.es_root }
           klass.define_singleton_method(:es_join_field) { join_field }
           klass.define_singleton_method(:es_join_name) { name }
           klass.define_method(:es_join_name) { name }
@@ -133,8 +133,6 @@ module ElasticRecord
         end
 
         name ||= to_s.demodulize.underscore
-        klass = self
-        define_singleton_method(:es_root) { klass }
         define_singleton_method(:es_join_field) { join_field }
         define_singleton_method(:es_join_name) { name }
         define_singleton_method(:es_descendants) do

--- a/test/elastic_record/model/joining_test.rb
+++ b/test/elastic_record/model/joining_test.rb
@@ -13,6 +13,11 @@ class ElasticRecord::Model::JoiningTest < MiniTest::Test
     Son.elastic_index.reset_deferring!
   end
 
+  def test_es_root
+    assert_equal Mother, Mother.es_root
+    assert_equal Mother, Son.es_root
+  end
+
   def test_es_children
     assert_equal [Son], Mother.es_descendants
   end

--- a/test/elastic_record/model/joining_test.rb
+++ b/test/elastic_record/model/joining_test.rb
@@ -14,6 +14,7 @@ class ElasticRecord::Model::JoiningTest < MiniTest::Test
   end
 
   def test_es_root
+    assert_equal Widget, Widget.es_root
     assert_equal Mother, Mother.es_root
     assert_equal Mother, Son.es_root
   end


### PR DESCRIPTION
### Problem

We'll frequently keep having to check if a place has an ES root before asking for it. Instead, why don't we just make roots the roots of themselves?

### Solution

Make it so.
