### PR TITLE
Define `metamorphose`, which initiates the same relation with a new class

### DIFF
--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -31,6 +31,12 @@ module ElasticRecord
       became
     end
 
+    def metamorphose(new_klass)
+      result = self.class.new(new_klass, values: values.dup)
+      result.safe! if safe?
+      result
+    end
+
     def count
       search_hits.total
     end

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -57,7 +57,7 @@ module ElasticRecord
         define_method ar_method do |*args, &block|
           result = klass.send(ar_method, *args, &block)
           if result.is_a?(ActiveRecord::Relation)
-            self.class.new(result, values: values)
+            metamorphose(result)
           else
             result
           end


### PR DESCRIPTION
### Problem

`includes` and other AR methods cause `Relation` instances to lose their `@safe` values.

### Solution

Define a method to instantiate a new relation with a new class, and use it when `includes` is called. Make it public facing, for good measure.