### PR TITLE
Safer way to disable deferring during testing

### DIFF
--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -164,13 +164,6 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
 
   private
 
-    def without_deferring(index)
-      index.disable_deferring!
-      yield
-      index.reset
-      index.enable_deferring!
-    end
-
     def index
       @index ||= Widget.elastic_index
     end

--- a/test/elastic_record/index/pagination_test.rb
+++ b/test/elastic_record/index/pagination_test.rb
@@ -18,11 +18,12 @@ class ElasticRecord::Index::PaginationTest < MiniTest::Test
     assert_equal 1, search_after.request_more_hits.hits.length
     assert_equal 3, search_after.total_hits
 
-    index.disable_deferring!
-    search_after = index.build_search_after(**options, use_point_in_time: true)
-    assert_equal 2, search_after.request_more_hits.hits.length
-    assert_equal 1, search_after.request_more_hits.hits.length
-    assert_equal 3, search_after.total_hits
+    without_deferring(index) do
+      search_after = index.build_search_after(**options, use_point_in_time: true)
+      assert_equal 2, search_after.request_more_hits.hits.length
+      assert_equal 1, search_after.request_more_hits.hits.length
+      assert_equal 3, search_after.total_hits
+    end
   end
 
   private

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -28,5 +28,12 @@ module MiniTest
         model.elastic_index.reset_deferring!
       end
     end
+
+    def without_deferring(index)
+      index.disable_deferring!
+      yield
+      index.reset
+      index.enable_deferring!
+    end
   end
 end


### PR DESCRIPTION
### Problem

We have an established, not-polluting way of disabling deferring for a test, but we're not using it everywhere.

### Solution

Move the helper method to `test_helper.rb` and use it everywhere.