### PR TITLE
Error when `search_after` attempts to use an expired point-in-time

### DIFF
--- a/lib/elastic_record/errors.rb
+++ b/lib/elastic_record/errors.rb
@@ -17,6 +17,12 @@ module ElasticRecord
   class ExpiredScrollError < Error
   end
 
+  class ExpiredPointInTime < Error
+  end
+
   class InvalidScrollError < Error
+  end
+
+  class InvalidPointInTimeError < Error
   end
 end

--- a/lib/elastic_record/index/deferred.rb
+++ b/lib/elastic_record/index/deferred.rb
@@ -73,12 +73,12 @@ module ElasticRecord
             READ_METHODS.include?(method) || flush_deferred_actions_for_json_post?(method, args.first)
           end
 
-          POST_PATHS_THAT_REQUIRE_FLUSH = [
+          POST_PATHS_THAT_TRIGGER_FLUSH = [
             /^\/_search\/scroll/,
             /^(.*)\/_pit/
           ].freeze
           def flush_deferred_actions_for_json_post?(method, arg)
-            method == :json_post && POST_PATHS_THAT_REQUIRE_FLUSH.any? { |path| arg =~ path }
+            method == :json_post && POST_PATHS_THAT_TRIGGER_FLUSH.any? { |path| arg =~ path }
           end
       end
 

--- a/lib/elastic_record/index/deferred.rb
+++ b/lib/elastic_record/index/deferred.rb
@@ -39,8 +39,10 @@ module ElasticRecord
 
             if expedite_request?(method, args)
               flush_deferred_actions!
-              if index_name = search_request(method, args)
+              if index_name = index_from_request(method, args)
                 index.real_connection.json_post("/#{index_name}/_refresh")
+              elsif method == :json_post
+                index.real_connection.json_post("/*/_refresh")
               end
 
               index.real_connection.send(method, *args, &block)
@@ -57,7 +59,7 @@ module ElasticRecord
             deferred_actions.clear
           end
 
-          def search_request(method, args)
+          def index_from_request(method, args)
             if method == :json_get && args.first =~ /^\/(.*)\/_m?search/
               $1.partition('/').first
             end

--- a/lib/elastic_record/index/pagination.rb
+++ b/lib/elastic_record/index/pagination.rb
@@ -28,6 +28,12 @@ module ElasticRecord
         else
           get '_search', elastic_query
         end
+      rescue ElasticRecord::ConnectionError => e
+        case e.status_code
+        when '400' then raise ElasticRecord::InvalidPointInTimeError, e.message
+        when '404' then raise ElasticRecord::ExpiredPointInTime, e.message
+        else raise e
+        end
       end
 
       private

--- a/lib/elastic_record/index/pagination.rb
+++ b/lib/elastic_record/index/pagination.rb
@@ -32,7 +32,7 @@ module ElasticRecord
         case e.status_code
         when '400' then raise ElasticRecord::InvalidPointInTimeError, e.message
         when '404' then raise ElasticRecord::ExpiredPointInTime, e.message
-        else raise e
+        else raise
         end
       end
 

--- a/lib/elastic_record/index/pagination.rb
+++ b/lib/elastic_record/index/pagination.rb
@@ -28,10 +28,10 @@ module ElasticRecord
         else
           get '_search', elastic_query
         end
-      rescue ElasticRecord::ConnectionError => e
+      rescue ConnectionError => e
         case e.status_code
-        when '400' then raise ElasticRecord::InvalidPointInTimeError, e.message
-        when '404' then raise ElasticRecord::ExpiredPointInTime, e.message
+        when '400' then raise InvalidPointInTimeError, e.message
+        when '404' then raise ExpiredPointInTime, e.message
         else raise
         end
       end

--- a/test/elastic_record/index/pagination_test.rb
+++ b/test/elastic_record/index/pagination_test.rb
@@ -40,7 +40,6 @@ class ElasticRecord::Index::PaginationTest < MiniTest::Test
 
   def test_each_slice
     10.times { |i| index.index_document("bob#{i}", { color: 'red' }) }
-    Widget.filter(Arelastic.queries.match_all).count # necessary for these documents to appear for some reason??
     batches = []
 
     search_after = index.build_search_after(
@@ -60,7 +59,6 @@ class ElasticRecord::Index::PaginationTest < MiniTest::Test
 
   def test_each_slice_with_few_records
     index.index_document("joe1", { color: 'pink' })
-    Widget.filter(Arelastic.queries.match_all).count # necessary for these documents to appear for some reason??
     batches = []
 
     search_after = index.build_search_after(

--- a/test/elastic_record/index/pagination_test.rb
+++ b/test/elastic_record/index/pagination_test.rb
@@ -40,6 +40,7 @@ class ElasticRecord::Index::PaginationTest < MiniTest::Test
 
   def test_each_slice
     10.times { |i| index.index_document("bob#{i}", { color: 'red' }) }
+    Widget.filter(Arelastic.queries.match_all).count # necessary for these documents to appear for some reason??
     batches = []
 
     search_after = index.build_search_after(
@@ -59,6 +60,7 @@ class ElasticRecord::Index::PaginationTest < MiniTest::Test
 
   def test_each_slice_with_few_records
     index.index_document("joe1", { color: 'pink' })
+    Widget.filter(Arelastic.queries.match_all).count # necessary for these documents to appear for some reason??
     batches = []
 
     search_after = index.build_search_after(

--- a/test/elastic_record/index/pagination_test.rb
+++ b/test/elastic_record/index/pagination_test.rb
@@ -26,6 +26,18 @@ class ElasticRecord::Index::PaginationTest < MiniTest::Test
     end
   end
 
+  def test_invalid_point_in_time_error
+    search_after = index.build_search_after(
+      keep_alive:       '1m',
+      point_in_time_id: 'foobar',
+      search:           { 'query' => { query_string: { query: 'name:bob' } } },
+      batch_size:       2,
+    )
+    assert_raises ElasticRecord::InvalidPointInTimeError do
+      search_after.request_more_hits
+    end
+  end
+
   private
 
     def index

--- a/test/elastic_record/index/pagination_test.rb
+++ b/test/elastic_record/index/pagination_test.rb
@@ -57,6 +57,21 @@ class ElasticRecord::Index::PaginationTest < MiniTest::Test
     end
   end
 
+  def test_each_slice_with_few_records
+    index.index_document("joe1", { color: 'pink' })
+    batches = []
+
+    search_after = index.build_search_after(
+      search:            { 'query' => { query_string: { query: 'color:pink' } } },
+      batch_size:        4,
+      use_point_in_time: true
+    )
+    search_after.each_slice do |slice|
+      batches << slice
+    end
+    assert_equal 1, batches.size
+  end
+
   private
 
     def index


### PR DESCRIPTION
Part of https://infogroup.atlassian.net/browse/INFO-9681

### Problem

`search_after` is too aggressive in its auto-management of PITs. When a PIT ID it's attempting to use is expired, it generates a new one and uses that. This means that records could appear twice in a single call to `search_after`.

### Solution

Error when `search_after` is attempting to use a PIT ID that's expired.