### PR TITLE
Fix deletion with routing

### DIFF
--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -71,7 +71,7 @@ module ElasticRecord
           batch << { delete: instructions }
         else
           path = "/#{index_name}/_doc/#{id}"
-          path << "&routing=#{routing}" if routing
+          path << "?routing=#{routing}" if routing
 
           connection.json_delete path
         end
@@ -82,7 +82,9 @@ module ElasticRecord
 
         scroll_enumerator.each_slice do |hits|
           bulk do
-            hits.each { |hit| delete_document hit['_id'] }
+            hits.each do |hit|
+              delete_document hit['_id'], routing: hit['_routing']
+            end
           end
         end
       end

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -60,7 +60,7 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     index.index_document('abc', { color: 'red' })
     assert index.record_exists?('abc')
 
-    index.delete_document('abc')
+    index.delete_document('abc', routing: 'abc')
     refute index.record_exists?('abc')
 
     assert_raises RuntimeError do


### PR DESCRIPTION
### Problems

- `delete_by_query` doesn't support deleting documents that require `routing` to be specified.
- `delete_document` improperly specifies query params when a `routing` value is specified.

### Solution

Fix 'em.

