### PR TITLE
preserve order of records when doing safe query

### DIFF
--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -70,7 +70,7 @@ module ElasticRecord
       else
         ids = search_hits.to_ids
         if safe?
-          klass.where(id: ids).to_a
+          klass.where(id: ids).to_a.sort_by { |doc| ids.index { |i| i.to_s == doc.id.to_s } }
         else
           klass.find ids
         end

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -42,13 +42,16 @@ class ElasticRecord::RelationTest < MiniTest::Test
   end
 
   def test_to_a
-    Widget.create!(color: 'red')
+    Widget.create!(color: 'green')
     Widget.create!(color: 'red')
 
-    array = Widget.elastic_relation.to_a
+    relation = Widget.elastic_search.order(color: :desc)
 
+    refute relation.safe?
+    array = relation.to_a
     assert_equal 2, array.size
     assert array.first.is_a?(Widget)
+    assert_equal 'red', array.first.color
   end
 
   def test_safe_load

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -52,10 +52,12 @@ class ElasticRecord::RelationTest < MiniTest::Test
   end
 
   def test_safe_load
+    Widget.create!(color: 'green')
+    Widget.create!(color: 'black')
     Widget.create!(color: 'red')
     Widget.elastic_index.index_record(Widget.new(color: 'blue'))
 
-    relation = Widget.elastic_relation
+    relation = Widget.elastic_search.order(color: :desc)
     assert_raises ActiveRecord::RecordNotFound do
       relation.to_a
     end
@@ -63,7 +65,7 @@ class ElasticRecord::RelationTest < MiniTest::Test
     array = relation.to_a
 
     assert relation.safe?
-    assert_equal 1, array.size
+    assert_equal 3, array.size
     assert_equal 'red', array.first.color
   end
 


### PR DESCRIPTION
[JIRA](https://infogroup.atlassian.net/browse/INFO-10493)

### Problem

Making a relation `safe` removes any ordering within the query, instead orders based on database internal ordering. 

### Solution

Resort the results from the database based on that from Elastic. 

This is demonstrated in data-axle/content_system#6982