### PR TITLE
Define `exists?` methods to mimic ActiveRecord

### DIFF
--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -41,6 +41,10 @@ module ElasticRecord
       search_hits.total
     end
 
+    def exists?(**conditions)
+      (conditions.empty? ? self : filter(**conditions)).count > 0
+    end
+
     def aggregations
       @aggregations ||= begin
         results = search_results['aggregations']

--- a/lib/elastic_record/relation/none.rb
+++ b/lib/elastic_record/relation/none.rb
@@ -13,6 +13,10 @@ module ElasticRecord
         {}
       end
 
+      def exists?(**conditions)
+        false
+      end
+
       def as_elastic
         Arelastic::Queries::MatchAll.new.negate.as_elastic
       end

--- a/test/elastic_record/relation/none_test.rb
+++ b/test/elastic_record/relation/none_test.rb
@@ -8,6 +8,8 @@ class ElasticRecord::Relation::NoneTest < MiniTest::Test
     assert_equal 0,     none.count
     assert_equal [],    none.to_a
     assert_equal({},    none.aggregations)
+    refute none.exists?
+    refute none.exists?(segment_id: 3)
 
     expected_elastic = {"bool" => {"must_not" => {"match_all" => {}}}}
     assert_equal expected_elastic, none.as_elastic

--- a/test/elastic_record/relation_test.rb
+++ b/test/elastic_record/relation_test.rb
@@ -22,6 +22,18 @@ class ElasticRecord::RelationTest < MiniTest::Test
     assert_equal 2, Widget.elastic_relation.count - original_count
   end
 
+  def test_exists
+    refute Widget.elastic_relation.exists?
+    refute Widget.elastic_relation.exists?(color: 'red')
+    refute Widget.elastic_relation.exists?(color: 'blue')
+
+    Widget.create!(color: 'red')
+
+    assert Widget.elastic_relation.exists?
+    assert Widget.elastic_relation.exists?(color: 'red')
+    refute Widget.elastic_relation.exists?(color: 'blue')
+  end
+
   def test_aggregations
     Widget.create!(color: 'red', price: 5)
     Widget.create!(color: 'blue', price: 10)


### PR DESCRIPTION
This will enable lines such as [this one](https://github.com/data-axle/content_system/blob/a254ab91b15b7b40fb240def24e1e76d88d66b9f/app/models/lookups/pruner.rb#L28) to look a little nicer.