### PR TITLE
after_commit all the things

### DIFF
--- a/lib/elastic_record/model/callbacks.rb
+++ b/lib/elastic_record/model/callbacks.rb
@@ -2,12 +2,12 @@ module ElasticRecord
   module Model
     module Callbacks
       def self.included(base)
-        return unless base.respond_to?(:after_save) &&  base.respond_to?(:after_destroy)
+        return unless base.respond_to?(:after_commit)
 
         base.class_eval do
-          after_create :index_to_elasticsearch
-          after_update :update_index_document, if: -> { respond_to?(:saved_changes?) ? saved_changes? : changed? }
-          after_destroy :delete_index_document
+          after_commit :index_to_elasticsearch, on: :create
+          after_commit :update_index_document, on: :update, if: -> { respond_to?(:saved_changes?) ? saved_changes? : changed? }
+          after_commit :delete_index_document, on: :destroy
         end
       end
 


### PR DESCRIPTION
### Problem

`after_save` and its friends may be called even after the transaction encapsulating the database operation is rolled back.

### Solution

Use `after_commit`

### Notes

Do not use after_create_commit etc because https://www.kostolansky.sk/posts/unexpected-after-commit-behaviour/

### Links

https://api.rubyonrails.org/v6.0.6.1/classes/ActiveRecord/Transactions/ClassMethods.html#method-i-after_commit
https://jakeyesbeck.com/page10/#aftercommit
https://blog1.westagilelabs.com/when-to-use-after-commit-in-rails-f5e53a22bb9

