### PR TITLE
Use ActiveSupport to encode JSON

### DIFF
--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'arelastic', '>= 3.4.0'
   s.add_dependency 'activemodel'
+  s.add_dependency 'activesupport'
 end

--- a/lib/elastic_record/connection.rb
+++ b/lib/elastic_record/connection.rb
@@ -38,11 +38,11 @@ module ElasticRecord
     end
 
     def json_request(method, path, payload)
-      payload = JSON.generate(payload) if payload.is_a?(Hash)
+      payload = ActiveSupport::JSON.encode(payload) if payload.is_a?(Hash)
 
       response = http_request_with_retry(method, path, payload)
 
-      response_body = JSON.parse(response.body)
+      response_body = ActiveSupport::JSON.decode(response.body)
       response_body['error'] ? raise_connection_error(response, payload) : response_body
     end
 

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -117,7 +117,7 @@ module ElasticRecord
           yield
 
           if current_bulk_batch.any?
-            body = current_bulk_batch.map { |action| "#{JSON.generate(action)}\n" }.join
+            body = current_bulk_batch.map { |action| "#{ActiveSupport::JSON.encode(action)}\n" }.join
             results = connection.json_post("/_bulk?#{options.to_query}", body)
             verify_bulk_results(results)
           end


### PR DESCRIPTION
**Problem:**
`ActiveSupport::TimeWithZone` objects do not get serialized in ISO8601 format when using JSON.generate. Use of Oj has hidden this deficiency previously.

**Solution:**
Use ActiveSupport JSON encoding when generation data for elastic search requests.