### PR TITLE
Return block's return value from Index#bulk

### DIFF
--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -114,12 +114,12 @@ module ElasticRecord
         def start_new_bulk_batch(options, &block)
           connection.bulk_actions = []
 
-          yield
-
-          if current_bulk_batch.any?
-            body = current_bulk_batch.map { |action| "#{ActiveSupport::JSON.encode(action)}\n" }.join
-            results = connection.json_post("/_bulk?#{options.to_query}", body)
-            verify_bulk_results(results)
+          yield.tap do
+            if current_bulk_batch.any?
+              body = current_bulk_batch.map { |action| "#{ActiveSupport::JSON.encode(action)}\n" }.join
+              results = connection.json_post("/_bulk?#{options.to_query}", body)
+              verify_bulk_results(results)
+            end
           end
         ensure
           connection.bulk_actions = nil

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -162,6 +162,14 @@ class ElasticRecord::Index::DocumentsTest < MiniTest::Test
     end
   end
 
+  def test_bulk_return_value
+    return_value = index.bulk do
+      42
+    end
+
+    assert_equal 42, return_value
+  end
+
   private
 
     def index


### PR DESCRIPTION
Right now,`Widget.elastic_index.bulk do` block returns 'nil`. If I want to return a value from within it, I have to do something like this:

```
saved_widgets = [].tap do |saved_widgets|
  Widget.elastic_index.bulk do
    saved_widgets.concat(widget.filter(&:save))
  end
end
```

The proposed change fixes `ElasticRecord::Index#start_new_bulk_batch` to return the value returned from the `yield`ed block making the following code possible:

```
saved_widgets = Widget.elastic_index.bulk do
  widget.filter(&:save)
end
```