### PR TITLE
Add native support for runtime mappings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'dotenv-rails'
-gem 'arelastic', github: 'data-axle/arelastic', branch: 'runtime-mappings'
+gem 'arelastic'
 gem 'oj'
 gem 'pg'
 gem 'rails', '~> 6.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'dotenv-rails'
-gem 'arelastic'
+gem 'arelastic', github: 'data-axle/arelastic', branch: 'runtime-mappings'
 gem 'oj'
 gem 'pg'
 gem 'rails', '~> 6.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     elastic_record (5.6.2)
       activemodel
       activesupport
-      arelastic (>= 3.4.0)
+      arelastic (>= 3.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -66,7 +66,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    arelastic (3.4.0)
+    arelastic (3.4.1)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crack (0.4.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    elastic_record (5.6.1)
+    elastic_record (5.6.2)
       activemodel
       activesupport
       arelastic (>= 3.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/data-axle/arelastic.git
-  revision: 345500f93dfbc1d78eeb2510f8ce84693711291d
-  branch: runtime-mappings
-  specs:
-    arelastic (3.4.0)
-
 PATH
   remote: .
   specs:
@@ -73,6 +66,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    arelastic (3.4.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
@@ -175,7 +169,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  arelastic!
+  arelastic
   dotenv-rails
   elastic_record!
   oj

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,16 @@
+GIT
+  remote: https://github.com/data-axle/arelastic.git
+  revision: 345500f93dfbc1d78eeb2510f8ce84693711291d
+  branch: runtime-mappings
+  specs:
+    arelastic (3.4.0)
+
 PATH
   remote: .
   specs:
     elastic_record (5.6.1)
       activemodel
+      activesupport
       arelastic (>= 3.4.0)
 
 GEM
@@ -65,7 +73,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
-    arelastic (3.4.0)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crack (0.4.5)
@@ -168,7 +175,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  arelastic
+  arelastic!
   dotenv-rails
   elastic_record!
   oj

--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files`.split("\n")
   s.test_files  = `git ls-files -- {test}/*`.split("\n")
 
-  s.add_dependency 'arelastic', '>= 3.4.0'
+  s.add_dependency 'arelastic', '>= 3.4.1'
   s.add_dependency 'activemodel'
   s.add_dependency 'activesupport'
 end

--- a/elastic_record.gemspec
+++ b/elastic_record.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'elastic_record'
-  s.version = '5.6.1'
+  s.version = '5.6.2'
   s.summary = 'An Elasticsearch querying ORM'
   s.description = 'Find your records with Elasticsearch'
 

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -178,9 +178,19 @@ module ElasticRecord
         build_search.as_elastic
       end
 
+      def runtime_mapping!(mapping)
+        self.runtime_mapping_values += [mapping]
+        self
+      end
+
+      def runtime_mapping(mapping)
+        clone.runtime_mapping! mapping
+      end
+
       private
         def build_search
           searches = [
+            build_runtime_mappings(runtime_mapping_values),
             build_query_and_filter(query_value, filter_values),
             build_limit(limit_value),
             build_offset(offset_value),
@@ -190,6 +200,10 @@ module ElasticRecord
           ].compact
 
           Arelastic::Nodes::HashGroup.new searches
+        end
+
+        def build_runtime_mappings(mapping_values)
+          Arelastic::Searches::RuntimeMappings.new(mapping_values.reduce(&:merge)) unless mapping_values.empty?
         end
 
         def build_query_and_filter(query, filters)

--- a/lib/elastic_record/relation/value_methods.rb
+++ b/lib/elastic_record/relation/value_methods.rb
@@ -1,6 +1,6 @@
 module ElasticRecord
   class Relation
-    MULTI_VALUE_METHODS  = [:extending, :filter, :order, :aggregation]
+    MULTI_VALUE_METHODS  = [:extending, :filter, :order, :aggregation, :runtime_mapping]
     SINGLE_VALUE_METHODS = [:query, :limit, :offset, :search_options, :search_type, :reverse_order]
   end
 end

--- a/test/elastic_record/relation/search_methods_test.rb
+++ b/test/elastic_record/relation/search_methods_test.rb
@@ -151,6 +151,19 @@ class ElasticRecord::Relation::SearchMethodsTest < MiniTest::Test
     assert_equal expected, relation.as_elastic['query']
   end
 
+  def test_runtime_mappings
+    script = "emit(doc['color'].value + ' ' + doc['warehouse_id'].value);"
+    mapping1 = { foo: { type: 'keyword', script: script } }
+    mapping2 = { bar: { type: 'keyword', script: script } }
+
+    relation.runtime_mapping!(mapping1)
+    mutated = relation.runtime_mapping(mapping2)
+
+    expected = { **mapping1, **mapping2 }
+
+    assert_equal expected, mutated.as_elastic['runtime_mappings']
+  end
+
   def test_aggregation_with_bang
     relation.aggregate!("tags" => {"terms" => {"field" => "tags"}})
 


### PR DESCRIPTION
### Problem

No native support for query-time runtime mappings. These are useful for obvious reasons. See [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-search-request.html#runtime-search-request).

### Solution

Support them.