### PR TITLE
Clone shared search values with *VALUE_METHODS

### DIFF
--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -31,6 +31,10 @@ module ElasticRecord
       became
     end
 
+    def metamorphose(new_klass)
+      self.class.new(new_klass, values: values.dup)
+    end
+
     def count
       search_hits.total
     end

--- a/lib/elastic_record/relation.rb
+++ b/lib/elastic_record/relation.rb
@@ -31,12 +31,6 @@ module ElasticRecord
       became
     end
 
-    def metamorphose(new_klass)
-      result = self.class.new(new_klass, values: values.dup)
-      result.safe! if safe?
-      result
-    end
-
     def count
       search_hits.total
     end
@@ -58,14 +52,6 @@ module ElasticRecord
 
     def to_a
       @records ||= find_hits(search_hits)
-    end
-
-    def safe!
-      @safe = true
-    end
-
-    def safe?
-      @safe
     end
 
     def find_hits(search_hits)

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -57,7 +57,7 @@ module ElasticRecord
         define_method ar_method do |*args, &block|
           result = klass.send(ar_method, *args, &block)
           if result.is_a?(ActiveRecord::Relation)
-            metamorphose(result)
+            self.class.new(result, values: values)
           else
             result
           end
@@ -102,6 +102,14 @@ module ElasticRecord
 
       def offset(value)
         clone.offset! value
+      end
+
+      def safe!
+        self.safe_value = true
+      end
+
+      def safe?
+        safe_value
       end
 
       def search_options!(options)

--- a/lib/elastic_record/relation/search_methods.rb
+++ b/lib/elastic_record/relation/search_methods.rb
@@ -57,7 +57,7 @@ module ElasticRecord
         define_method ar_method do |*args, &block|
           result = klass.send(ar_method, *args, &block)
           if result.is_a?(ActiveRecord::Relation)
-            self.class.new(result, values: values)
+            metamorphose(result)
           else
             result
           end

--- a/lib/elastic_record/relation/value_methods.rb
+++ b/lib/elastic_record/relation/value_methods.rb
@@ -1,6 +1,6 @@
 module ElasticRecord
   class Relation
     MULTI_VALUE_METHODS  = [:extending, :filter, :order, :aggregation, :runtime_mapping]
-    SINGLE_VALUE_METHODS = [:query, :limit, :offset, :search_options, :search_type, :reverse_order]
+    SINGLE_VALUE_METHODS = [:query, :limit, :offset, :search_options, :safe, :search_type, :reverse_order]
   end
 end


### PR DESCRIPTION
### Problem

On #147 @j1wilmot added support for `safe` and #153 @matthinea added metamorphose to copy the value of `@safe` to a newly created Relation. Relation already has support for this as part of `*_value` methods defined with `SINGLE_VALUE_METHODS`. These methods are set on the `values` hash and copied to the new object when an active record method is called.


### Solution

* Defined `:safe` on `SINGLE_VALUE_METHODS`
* Move definition of `safe!` and `safe?` to `SearchMethods`
* Clone relations with klass.new

P.S. Howdy guys! I was reading through the repo and saw this little bike shed. 