### PR TITLE
Use source ID as object ID when present

### DIFF
--- a/lib/elastic_record/model/from_search_hit.rb
+++ b/lib/elastic_record/model/from_search_hit.rb
@@ -3,15 +3,16 @@ module ElasticRecord
     module FromSearchHit
 
       def from_search_hit(hit)
-        hit = hit['_source'].merge('id' => hit['_id'])
+        attrs         = hit['_source']
+        attrs['id'] ||= hit['_id']
 
-        attrs = value_from_search_hit_object(hit)
+        cast_attrs = value_from_search_hit_object(attrs)
 
         if respond_to?(:instantiate)
-          instantiate(attrs)
+          instantiate(cast_attrs)
         else
           self.new.tap do |record|
-            attrs.each do |k, v|
+            cast_attrs.each do |k, v|
               record.send("#{k}=", v) if record.respond_to?("#{k}=")
             end
           end

--- a/test/elastic_record/from_search_hits_test.rb
+++ b/test/elastic_record/from_search_hits_test.rb
@@ -37,6 +37,27 @@ class ElasticRecord::FromSearchHitsTest < Minitest::Test
     assert_equal 25..30, document.manager['estimated_age']
   end
 
+  def test_id
+    document = Project.from_search_hit({
+      '_id' => 'elastic_id',
+      '_source' => {
+        'name' => 'foo',
+        'id' => 'source_id',
+      }
+    })
+
+    assert_equal 'source_id', document.id
+
+    document = Project.from_search_hit({
+      '_id' => 'elastic_id',
+      '_source' => {
+        'name' => 'foo',
+      }
+    })
+
+    assert_equal 'elastic_id', document.id
+  end
+
   private
 
     def manager


### PR DESCRIPTION
## Problem

If `from_search_hit` is passed a hit in an `inner_hits` object, the resulting instantiated object will have the ID of the parent object rather than the ID of the nested object returned by `inner_hits`. This is because the `_id` of `inner_hit` hits is the ID of the top-level "parent" document.

For example, consider an index of "place" documents where each place has nested "location_intents" documents. A hit in the `inner_hits` `hits` array will look like this:

```
{
  "_index" : "places",
  "_type" : "_doc",
  "_id" : "761522765",
  "_nested" : {
    "field" : "location_intents",
    "offset" : 4
  },
  "_score" : 3.459679,
  "_source" : {
    "score" : 65.0,
    "topic_ids" : [
      "f5d7ec74b5",
      "22d32051bd",
      "1a9bf45c5d"
    ],
    "vendor_id" : "888",
    "id" : "4528bd6f82a1489aa3aab1e09e6e7b67"
  }
}
```

When passed this object, `from_search_hit` will instantiate an object with an ID of `761522765`, the top-level "place" document's ID. The actual ID of the nested object will be thrown out.

## Solution

If there's an `id` key in the `_source` hash, instantiate an object with that ID. Otherwise, continue using the unnested `_id` field in the hit.