### PR TITLE
Send `_bulk` actions in batches

### DIFF
--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -121,16 +121,18 @@ module ElasticRecord
           connection.bulk_actions = nil
         end
 
+        ACTIONS_PER_BULK = 1_000
+
         def json_post_bulk(options)
-          # chunk into 1000 actions at a time
-          # add error handling for "client intended to send too large body"
-          body    = current_bulk_batch.map { |action| "#{ActiveSupport::JSON.encode(action)}\n" }.join
-          results = connection.json_post("/_bulk?#{options.to_query}", body)
+          current_bulk_batch.each_slice(ACTIONS_PER_BULK) do |actions|
+            body    = actions.map { |action| "#{ActiveSupport::JSON.encode(action)}\n" }.join
+            results = connection.json_post("/_bulk?#{options.to_query}", body)
 
-          if results.is_a?(Hash)
-            errors = results['items'].select { |item| item.values.first['error'] }
+            if results.is_a?(Hash)
+              errors = results['items'].select { |item| item.values.first['error'] }
 
-            raise ElasticRecord::BulkError.new(errors) unless errors.empty?
+              raise ElasticRecord::BulkError.new(errors) unless errors.empty?
+            end
           end
         end
     end

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -30,8 +30,7 @@ module ElasticRecord
           instructions = { _index: index_name, _id: id }
           instructions[:routing] = routing if routing
 
-          batch << { index: instructions }
-          batch << document
+          batch << [{ index: instructions }, document]
         else
           path = "/#{index_name}/_doc/#{id}"
           path << "?routing=#{routing}" if routing
@@ -52,8 +51,7 @@ module ElasticRecord
           instructions = { _index: index_name, _id: id, retry_on_conflict: 3 }
           instructions[:routing] = routing if routing
 
-          batch << { update: instructions }
-          batch << params
+          batch << [{ update: instructions }, params]
         else
           path = "/#{index_name}/_update/#{id}?retry_on_conflict=3"
           path << "&routing=#{routing}" if routing
@@ -68,7 +66,7 @@ module ElasticRecord
         if batch = current_bulk_batch
           instructions = { _index: index_name, _id: id, retry_on_conflict: 3 }
           instructions[:routing] = routing if routing
-          batch << { delete: instructions }
+          batch << [{ delete: instructions }]
         else
           path = "/#{index_name}/_doc/#{id}"
           path << "?routing=#{routing}" if routing
@@ -124,8 +122,10 @@ module ElasticRecord
         ACTIONS_PER_BULK = 1_000
 
         def json_post_bulk(options)
-          current_bulk_batch.each_slice(ACTIONS_PER_BULK) do |actions|
-            body    = actions.map { |action| "#{ActiveSupport::JSON.encode(action)}\n" }.join
+          slice_size = options.delete(:actions_per_bulk) || ACTIONS_PER_BULK
+
+          current_bulk_batch.each_slice(slice_size) do |actions|
+            body    = actions.flatten.map { |action| "#{ActiveSupport::JSON.encode(action)}\n" }.join
             results = connection.json_post("/_bulk?#{options.to_query}", body)
 
             if results.is_a?(Hash)

--- a/lib/elastic_record/index/documents.rb
+++ b/lib/elastic_record/index/documents.rb
@@ -122,6 +122,8 @@ module ElasticRecord
         end
 
         def json_post_bulk(options)
+          # chunk into 1000 actions at a time
+          # add error handling for "client intended to send too large body"
           body    = current_bulk_batch.map { |action| "#{ActiveSupport::JSON.encode(action)}\n" }.join
           results = connection.json_post("/_bulk?#{options.to_query}", body)
 

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -88,15 +88,15 @@ class ElasticRecord::Index::DocumentsTest < Minitest::Test
 
       expected = [
         [
-          { index: { _index: index.alias_name, _id: "5" } },
-          { color: "green" }
+          { index: { _index: index.alias_name, _id: '5' } },
+          { color: 'green' }
         ],
         [
-          { update: { _index: "widgets", _id: "5", retry_on_conflict: 3 } },
-          { doc: { color: "blue" }, doc_as_upsert: true }
+          { update: { _index: 'widgets', _id: '5', retry_on_conflict: 3 } },
+          { doc: { color: 'blue' }, doc_as_upsert: true }
         ],
         [
-          {delete: { _index: index.alias_name, _id: "3", retry_on_conflict: 3 } }
+          {delete: { _index: index.alias_name, _id: '3', retry_on_conflict: 3 } }
         ],
       ]
 
@@ -195,8 +195,8 @@ class ElasticRecord::Index::DocumentsTest < Minitest::Test
 
         expected = [
           [
-            { index: { _index: index.alias_name, _id: "5" } },
-            { color: "green" },
+            { index: { _index: index.alias_name, _id: '5' } },
+            { color: 'green' },
           ]
         ]
 

--- a/test/elastic_record/index/documents_test.rb
+++ b/test/elastic_record/index/documents_test.rb
@@ -87,17 +87,59 @@ class ElasticRecord::Index::DocumentsTest < Minitest::Test
       index.delete_document '3'
 
       expected = [
-        {index: {_index: index.alias_name, _id: "5"}},
-        {color: "green"},
-        {update: {_index: "widgets", _id: "5", retry_on_conflict: 3}},
-        {doc: {color: "blue"}, doc_as_upsert: true},
-        {delete: {_index: index.alias_name, _id: "3", retry_on_conflict: 3}}
+        [
+          { index: { _index: index.alias_name, _id: "5" } },
+          { color: "green" }
+        ],
+        [
+          { update: { _index: "widgets", _id: "5", retry_on_conflict: 3 } },
+          { doc: { color: "blue" }, doc_as_upsert: true }
+        ],
+        [
+          {delete: { _index: index.alias_name, _id: "3", retry_on_conflict: 3 } }
+        ],
       ]
 
       assert_equal expected, index.current_bulk_batch
     end
 
     assert_nil index.current_bulk_batch
+  end
+
+  def test_bulk_batched
+    assert_nil index.current_bulk_batch
+
+    connection = index.connection
+    post_calls = []
+
+    # stub to collect post_calls:
+    connection.define_singleton_method(:json_post) do |endpoint, body|
+      post_calls << [endpoint, body]
+    end
+
+    begin
+      index.bulk(actions_per_bulk: 2) do
+        index.index_document '5', { color: 'green' }
+        index.delete_document '3'
+        index.update_document '5', { color: 'blue' }
+        index.update_document '5', { color: 'orange' }
+        index.update_document '4', { color: 'black' }
+      end
+
+      assert_equal 3, post_calls.length
+      expected_body = <<~DOC
+        {"index":{"_index":"widgets","_id":"5"}}
+        {"color":"green"}
+        {"delete":{"_index":"widgets","_id":"3","retry_on_conflict":3}}
+      DOC
+      assert_equal ['/_bulk?', expected_body], post_calls.first
+      assert_nil index.current_bulk_batch
+    ensure
+      class << connection
+        remove_method :json_post
+      end
+    end
+
   end
 
   def test_bulk_nested
@@ -152,8 +194,10 @@ class ElasticRecord::Index::DocumentsTest < Minitest::Test
         InheritedWidget.elastic_index.index_document '5', { color: 'green' }
 
         expected = [
-          {index: {_index: index.alias_name, _id: "5"}},
-          {color: "green"}
+          [
+            { index: { _index: index.alias_name, _id: "5" } },
+            { color: "green" },
+          ]
         ]
 
 

--- a/test/elastic_record/model/joining_test.rb
+++ b/test/elastic_record/model/joining_test.rb
@@ -104,11 +104,14 @@ class ElasticRecord::Model::JoiningTest < Minitest::Test
       index.index_record(son)
 
       expected = [
-        {index: {_index: index.alias_name, _id: 9}},
-        {"name" => "Queen Victoria", "arbitrary" => {"name" => "mother"}},
-        {index: {_index: index.alias_name, _id: 10, routing: "9"}},
-        {"name" => "King Edward VII", "warehouse_id" => "9", "arbitrary" => {"name" => "son", "parent" => "9"}}
-
+        [
+          { index: { _index: index.alias_name, _id: 9 } },
+          { "name" => "Queen Victoria", "arbitrary" => { "name" => "mother" } },
+        ],
+        [
+          { index: { _index: index.alias_name, _id: 10, routing: "9" } },
+          { "name" => "King Edward VII", "warehouse_id" => "9", "arbitrary" => { "name" => "son", "parent" => "9" } },
+        ],
       ]
 
       assert_equal expected, index.current_bulk_batch

--- a/test/elastic_record/model/joining_test.rb
+++ b/test/elastic_record/model/joining_test.rb
@@ -106,11 +106,11 @@ class ElasticRecord::Model::JoiningTest < Minitest::Test
       expected = [
         [
           { index: { _index: index.alias_name, _id: 9 } },
-          { "name" => "Queen Victoria", "arbitrary" => { "name" => "mother" } },
+          { 'name' => 'Queen Victoria', 'arbitrary' => { 'name' => 'mother' } },
         ],
         [
-          { index: { _index: index.alias_name, _id: 10, routing: "9" } },
-          { "name" => "King Edward VII", "warehouse_id" => "9", "arbitrary" => { "name" => "son", "parent" => "9" } },
+          { index: { _index: index.alias_name, _id: 10, routing: '9' } },
+          { 'name' => 'King Edward VII', 'warehouse_id' => '9', 'arbitrary' => { 'name' => 'son', 'parent' => '9' } },
         ],
       ]
 


### PR DESCRIPTION
## Problem

It's deceptively easy to load hundreds of thousands of records into a single `_bulk` request. These can result in `413: Request too large exception`, failing silently.

## Solution

Batch `_bulk` requests and only send max 1000 records at a time.

