### PR TITLE
Raise `ConnectionError` on most non-200 errors

### DIFF
--- a/lib/elastic_record/connection.rb
+++ b/lib/elastic_record/connection.rb
@@ -22,7 +22,7 @@ module ElasticRecord
     end
 
     def json_get(path, json = nil)
-      json_request :get, path, json
+      json_request :get, path, json, consider_ok: 404
     end
 
     def json_post(path, json = nil)
@@ -34,15 +34,19 @@ module ElasticRecord
     end
 
     def json_delete(path, json = nil)
-      json_request :delete, path, json
+      json_request :delete, path, json, consider_ok: 404
     end
 
-    def json_request(method, path, payload)
+    def json_request(method, path, payload, consider_ok: [])
       payload = ActiveSupport::JSON.encode(payload) if payload.is_a?(Hash)
 
       response = http_request_with_retry(method, path, payload)
 
-      raise_connection_error(response, payload) unless (200..299).cover?(response.code.to_i)
+      code = response.code.to_i
+
+      unless (200..299).cover?(code) || Array.wrap(consider_ok).include?(code)
+        raise_connection_error(response, payload)
+      end
 
       response_body = ActiveSupport::JSON.decode(response.body)
       response_body['error'] ? raise_connection_error(response, payload) : response_body

--- a/lib/elastic_record/connection.rb
+++ b/lib/elastic_record/connection.rb
@@ -18,11 +18,11 @@ module ElasticRecord
     end
 
     def head(path)
-      http_request_with_retry(:head, path).code
+      http_request_with_retry(:head, path, nil, [404]).code
     end
 
     def json_get(path, json = nil)
-      json_request :get, path, json, consider_ok: 404
+      json_request :get, path, json, ok_statuses: [404]
     end
 
     def json_post(path, json = nil)
@@ -34,31 +34,30 @@ module ElasticRecord
     end
 
     def json_delete(path, json = nil)
-      json_request :delete, path, json, consider_ok: 404
+      json_request :delete, path, json, ok_statuses: [404]
     end
 
-    def json_request(method, path, payload, consider_ok: [])
+    def json_request(method, path, payload, ok_statuses: [])
       payload = ActiveSupport::JSON.encode(payload) if payload.is_a?(Hash)
 
-      response = http_request_with_retry(method, path, payload)
-
-      code = response.code.to_i
-
-      unless (200..299).cover?(code) || Array.wrap(consider_ok).include?(code)
-        raise_connection_error(response, payload)
-      end
+      response = http_request_with_retry(method, path, payload, ok_statuses)
 
       response_body = ActiveSupport::JSON.decode(response.body)
       response_body['error'] ? raise_connection_error(response, payload) : response_body
     end
 
-    def http_request_with_retry(method, path, payload = nil)
+    STATUS_200 = (200..299).freeze
+
+    def http_request_with_retry(method, path, payload = nil, ok_statuses = [])
       with_retry do
         response = http_request(method, path, payload)
+        code = response.code.to_i
 
-        raise_connection_error(response, payload) if response.code.to_i >= 500
-
-        response
+        if STATUS_200.cover?(code) || ok_statuses.include?(code)
+          response
+        else
+          raise_connection_error(response, payload)
+        end
       end
     end
 

--- a/lib/elastic_record/connection.rb
+++ b/lib/elastic_record/connection.rb
@@ -42,6 +42,8 @@ module ElasticRecord
 
       response = http_request_with_retry(method, path, payload)
 
+      raise_connection_error(response, payload) unless (200..299).cover?(response.code.to_i)
+
       response_body = ActiveSupport::JSON.decode(response.body)
       response_body['error'] ? raise_connection_error(response, payload) : response_body
     end

--- a/test/elastic_record/connection_test.rb
+++ b/test/elastic_record/connection_test.rb
@@ -30,6 +30,17 @@ class ElasticRecord::ConnectionTest < Minitest::Test
     assert_equal expected, connection.json_put("/test")
   end
 
+  def test_json_request_400_errors
+    stub_es_request(:get, "/test").to_return(status: 413, body: 'client intended to send too large a body')
+
+    error =
+      assert_raises ElasticRecord::ConnectionError do
+        connection.json_get("/test")
+      end
+
+    assert_equal '413', error.status_code
+  end
+
   def test_json_request_with_valid_error_status
     request  = { 'some' => 'payload' }
     response = { 'error' => 'Doing it wrong' }

--- a/test/elastic_record/connection_test.rb
+++ b/test/elastic_record/connection_test.rb
@@ -66,8 +66,8 @@ class ElasticRecord::ConnectionTest < Minitest::Test
     result =
       begin
         connection.json_get('/places/_doc/123')
-      rescue
-        raise StandardError.new('"get" requests without error bodies should not raise!')
+      rescue ElasticRecord::ConnectionError
+        flunk('404 GET without error should not raise')
       end
 
     assert_equal response, result
@@ -79,7 +79,12 @@ class ElasticRecord::ConnectionTest < Minitest::Test
 
     stub_es_request(:delete, '/_pit').to_return(status: 404, body: response.to_json)
 
-    result = connection.json_delete('/_pit', request.to_json)
+    result =
+      begin
+        connection.json_delete('/_pit', request.to_json)
+      rescue ElasticRecord::ConnectionError
+        flunk('404 DELETE without error should not raise')
+      end
 
     assert_equal response, result
   end

--- a/test/elastic_record/connection_test.rb
+++ b/test/elastic_record/connection_test.rb
@@ -73,6 +73,17 @@ class ElasticRecord::ConnectionTest < Minitest::Test
     assert_equal response, result
   end
 
+  def test_json_delete_404_without_error
+    request  = { 'id' => 'expired_pit' }
+    response = { 'succeeded' => false, 'num_freed' => 0 }
+
+    stub_es_request(:delete, '/_pit').to_return(status: 404, body: response.to_json)
+
+    result = connection.json_delete('/_pit', request.to_json)
+
+    assert_equal response, result
+  end
+
   def test_json_request_with_valid_error_status
     request  = { 'some' => 'payload' }
     response = { 'error' => 'Doing it wrong' }

--- a/test/elastic_record/connection_test.rb
+++ b/test/elastic_record/connection_test.rb
@@ -31,24 +31,24 @@ class ElasticRecord::ConnectionTest < Minitest::Test
   end
 
   def test_json_get_413_error
-    stub_es_request(:get, "/test").to_return(status: 413, body: 'client intended to send too large a body')
+    stub_es_request(:get, '/test').to_return(status: 413, body: 'client intended to send too large a body')
 
     error =
       assert_raises ElasticRecord::ConnectionError do
-        connection.json_get("/test")
+        connection.json_get('/test')
       end
 
     assert_equal '413', error.status_code
   end
 
   def test_json_get_404_error
-    response = { error: { type: "index_not_found_exception" } }
+    response = { error: { type: 'index_not_found_exception' } }
 
-    stub_es_request(:get, "/test").to_return(status: 404, body: response.to_json)
+    stub_es_request(:get, '/test').to_return(status: 404, body: response.to_json)
 
     error =
       assert_raises ElasticRecord::ConnectionError do
-        connection.json_get("/test")
+        connection.json_get('/test')
       end
 
     expected = {

--- a/test/elastic_record/connection_test.rb
+++ b/test/elastic_record/connection_test.rb
@@ -30,7 +30,7 @@ class ElasticRecord::ConnectionTest < Minitest::Test
     assert_equal expected, connection.json_put("/test")
   end
 
-  def test_json_get_413_error
+  def test_json_get_413_no_error
     stub_es_request(:get, '/test').to_return(status: 413, body: 'client intended to send too large a body')
 
     error =
@@ -41,7 +41,7 @@ class ElasticRecord::ConnectionTest < Minitest::Test
     assert_equal '413', error.status_code
   end
 
-  def test_json_get_404_error
+  def test_json_get_404_with_error
     response = { error: { type: 'index_not_found_exception' } }
 
     stub_es_request(:get, '/test').to_return(status: 404, body: response.to_json)
@@ -56,6 +56,21 @@ class ElasticRecord::ConnectionTest < Minitest::Test
       request_payload:        nil,
     }.to_json
     assert_equal expected, error.message
+  end
+
+  def test_json_get_404_without_error
+    response = { '_index' => 'places', '_id' => '123', 'found' => false }
+
+    stub_es_request(:get, '/places/_doc/123').to_return(status: 404, body: response.to_json)
+
+    result =
+      begin
+        connection.json_get('/places/_doc/123')
+      rescue
+        raise StandardError.new('"get" requests without error bodies should not raise!')
+      end
+
+    assert_equal response, result
   end
 
   def test_json_request_with_valid_error_status

--- a/test/elastic_record/connection_test.rb
+++ b/test/elastic_record/connection_test.rb
@@ -30,7 +30,7 @@ class ElasticRecord::ConnectionTest < Minitest::Test
     assert_equal expected, connection.json_put("/test")
   end
 
-  def test_json_request_400_errors
+  def test_json_get_413_error
     stub_es_request(:get, "/test").to_return(status: 413, body: 'client intended to send too large a body')
 
     error =
@@ -39,6 +39,23 @@ class ElasticRecord::ConnectionTest < Minitest::Test
       end
 
     assert_equal '413', error.status_code
+  end
+
+  def test_json_get_404_error
+    response = { error: { type: "index_not_found_exception" } }
+
+    stub_es_request(:get, "/test").to_return(status: 404, body: response.to_json)
+
+    error =
+      assert_raises ElasticRecord::ConnectionError do
+        connection.json_get("/test")
+      end
+
+    expected = {
+      elasticsearch_response: response,
+      request_payload:        nil,
+    }.to_json
+    assert_equal expected, error.message
   end
 
   def test_json_request_with_valid_error_status


### PR DESCRIPTION
## Problem

Most methods interface with Elasticsearch via `json_request`. The `json_request` method only raises on 5xx errors, or when there's an explicity `error` key in the JSON response. This leaves 3xx and 4xx errors as silent failures.

## Solution

* For `post` and `put` methods, raise unless the response code is 2xx.
* For 'get' and 'delete' methods, additionally allow 404 Not Found, since apparently some methods rely on that.